### PR TITLE
feat: add thread-safe Queue for TurboAPI handlers

### DIFF
--- a/python/turboapi/__init__.py
+++ b/python/turboapi/__init__.py
@@ -66,6 +66,9 @@ from .middleware import (
 # Background tasks
 from .background import BackgroundTasks
 
+# Queue (thread-safe, works without asyncio event loop)
+from .queue import Queue, QueueEmpty, QueueFull
+
 # WebSocket
 from .websockets import WebSocket, WebSocketDisconnect
 
@@ -128,6 +131,10 @@ __all__ = [
     "TrustedHostMiddleware",
     # Background tasks
     "BackgroundTasks",
+    # Queue
+    "Queue",
+    "QueueEmpty",
+    "QueueFull",
     # WebSocket
     "WebSocket",
     "WebSocketDisconnect",

--- a/python/turboapi/queue.py
+++ b/python/turboapi/queue.py
@@ -1,0 +1,182 @@
+"""Thread-safe in-memory queue for TurboAPI.
+
+Drop-in replacement for asyncio.Queue that works from Tokio worker threads.
+Uses threading.Condition + collections.deque for true thread safety,
+including Python 3.13+ free-threading (no GIL dependency).
+
+Usage:
+    from turboapi import Queue, QueueEmpty, QueueFull
+
+    task_queue = Queue(maxsize=100)
+
+    @app.post("/enqueue")
+    def enqueue(data: dict):
+        task_queue.put(data)
+        return {"queued": task_queue.qsize()}
+
+    @app.get("/dequeue")
+    def dequeue():
+        try:
+            item = task_queue.get(timeout=5.0)
+            return {"item": item}
+        except QueueEmpty:
+            return {"error": "timeout"}, 408
+"""
+
+import threading
+import time
+from collections import deque
+from typing import Any, Optional
+
+
+class QueueEmpty(Exception):
+    """Raised when get_nowait() is called on an empty queue."""
+    pass
+
+
+class QueueFull(Exception):
+    """Raised when put_nowait() is called on a full queue."""
+    pass
+
+
+class Queue:
+    """Thread-safe FIFO queue for TurboAPI handlers.
+
+    Works from both sync and async TurboAPI handlers without requiring
+    an asyncio event loop. Safe for Python 3.13+ free-threading.
+
+    Args:
+        maxsize: Maximum number of items. 0 means unlimited (default).
+    """
+
+    def __init__(self, maxsize: int = 0):
+        self.maxsize: int = maxsize
+        self._queue: deque = deque()
+        self._mutex: threading.Lock = threading.Lock()
+        self._not_empty: threading.Condition = threading.Condition(self._mutex)
+        self._not_full: threading.Condition = threading.Condition(self._mutex)
+        self._unfinished_tasks: int = 0
+        self._all_done: threading.Condition = threading.Condition(self._mutex)
+
+    def put(self, item: Any, block: bool = True, timeout: Optional[float] = None) -> None:
+        """Put an item into the queue.
+
+        Args:
+            item: The item to enqueue.
+            block: Whether to block if the queue is full.
+            timeout: Maximum seconds to wait (None = wait forever).
+
+        Raises:
+            QueueFull: If the queue is full and block=False or timeout expires.
+        """
+        with self._not_full:
+            if self.maxsize > 0:
+                if not block:
+                    if len(self._queue) >= self.maxsize:
+                        raise QueueFull()
+                elif timeout is not None:
+                    if timeout < 0:
+                        raise ValueError("'timeout' must be a non-negative number")
+                    deadline = time.monotonic() + timeout
+                    while len(self._queue) >= self.maxsize:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            raise QueueFull()
+                        self._not_full.wait(timeout=remaining)
+                else:
+                    while len(self._queue) >= self.maxsize:
+                        self._not_full.wait()
+
+            self._queue.append(item)
+            self._unfinished_tasks += 1
+            self._not_empty.notify()
+
+    def get(self, block: bool = True, timeout: Optional[float] = None) -> Any:
+        """Remove and return an item from the queue.
+
+        Args:
+            block: Whether to block if the queue is empty.
+            timeout: Maximum seconds to wait (None = wait forever).
+
+        Returns:
+            The next item from the queue.
+
+        Raises:
+            QueueEmpty: If the queue is empty and block=False or timeout expires.
+        """
+        with self._not_empty:
+            if not block:
+                if not self._queue:
+                    raise QueueEmpty()
+            elif timeout is not None:
+                if timeout < 0:
+                    raise ValueError("'timeout' must be a non-negative number")
+                deadline = time.monotonic() + timeout
+                while not self._queue:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise QueueEmpty()
+                    self._not_empty.wait(timeout=remaining)
+            else:
+                while not self._queue:
+                    self._not_empty.wait()
+
+            item = self._queue.popleft()
+            self._not_full.notify()
+            return item
+
+    def put_nowait(self, item: Any) -> None:
+        """Put an item without blocking. Raises QueueFull if full."""
+        return self.put(item, block=False)
+
+    def get_nowait(self) -> Any:
+        """Get an item without blocking. Raises QueueEmpty if empty."""
+        return self.get(block=False)
+
+    def qsize(self) -> int:
+        """Return the approximate number of items in the queue."""
+        with self._mutex:
+            return len(self._queue)
+
+    def empty(self) -> bool:
+        """Return True if the queue is empty."""
+        with self._mutex:
+            return len(self._queue) == 0
+
+    def full(self) -> bool:
+        """Return True if the queue is full (always False if maxsize=0)."""
+        with self._mutex:
+            if self.maxsize <= 0:
+                return False
+            return len(self._queue) >= self.maxsize
+
+    def task_done(self) -> None:
+        """Signal that a previously enqueued task is complete.
+
+        Raises:
+            ValueError: If called more times than items placed in the queue.
+        """
+        with self._all_done:
+            if self._unfinished_tasks <= 0:
+                raise ValueError("task_done() called too many times")
+            self._unfinished_tasks -= 1
+            if self._unfinished_tasks == 0:
+                self._all_done.notify_all()
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        """Block until all items have been gotten and processed.
+
+        Args:
+            timeout: Maximum seconds to wait (None = wait forever).
+        """
+        with self._all_done:
+            if timeout is not None:
+                deadline = time.monotonic() + timeout
+                while self._unfinished_tasks > 0:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        return
+                    self._all_done.wait(timeout=remaining)
+            else:
+                while self._unfinished_tasks > 0:
+                    self._all_done.wait()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Tests for TurboAPI thread-safe Queue."""
+
+import sys
+import os
+import time
+import threading
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'python'))
+
+import pytest
+from turboapi.queue import Queue, QueueEmpty, QueueFull
+
+
+class TestQueueBasicOperations:
+
+    def test_put_and_get(self):
+        q = Queue()
+        q.put("item1")
+        q.put("item2")
+        assert q.get() == "item1"
+        assert q.get() == "item2"
+
+    def test_fifo_order(self):
+        q = Queue()
+        for i in range(100):
+            q.put(i)
+        for i in range(100):
+            assert q.get() == i
+
+    def test_qsize(self):
+        q = Queue()
+        assert q.qsize() == 0
+        q.put("a")
+        assert q.qsize() == 1
+        q.put("b")
+        assert q.qsize() == 2
+        q.get()
+        assert q.qsize() == 1
+
+    def test_empty(self):
+        q = Queue()
+        assert q.empty()
+        q.put("a")
+        assert not q.empty()
+
+    def test_full_unbounded(self):
+        q = Queue()
+        for i in range(1000):
+            q.put(i)
+        assert not q.full()
+
+    def test_full_bounded(self):
+        q = Queue(maxsize=2)
+        assert not q.full()
+        q.put("a")
+        assert not q.full()
+        q.put("b")
+        assert q.full()
+
+
+class TestQueueNonBlocking:
+
+    def test_get_nowait_empty_raises(self):
+        q = Queue()
+        with pytest.raises(QueueEmpty):
+            q.get_nowait()
+
+    def test_put_nowait_full_raises(self):
+        q = Queue(maxsize=1)
+        q.put("a")
+        with pytest.raises(QueueFull):
+            q.put_nowait("b")
+
+    def test_get_nowait_succeeds(self):
+        q = Queue()
+        q.put("hello")
+        assert q.get_nowait() == "hello"
+
+    def test_put_nowait_succeeds(self):
+        q = Queue(maxsize=1)
+        q.put_nowait("a")
+        assert q.get() == "a"
+
+
+class TestQueueTimeout:
+
+    def test_get_timeout_empty_raises(self):
+        q = Queue()
+        start = time.monotonic()
+        with pytest.raises(QueueEmpty):
+            q.get(timeout=0.1)
+        elapsed = time.monotonic() - start
+        assert elapsed >= 0.09
+
+    def test_put_timeout_full_raises(self):
+        q = Queue(maxsize=1)
+        q.put("a")
+        start = time.monotonic()
+        with pytest.raises(QueueFull):
+            q.put("b", timeout=0.1)
+        elapsed = time.monotonic() - start
+        assert elapsed >= 0.09
+
+    def test_get_timeout_succeeds_when_item_arrives(self):
+        q = Queue()
+
+        def delayed_put():
+            time.sleep(0.05)
+            q.put("hello")
+
+        t = threading.Thread(target=delayed_put)
+        t.start()
+        item = q.get(timeout=5.0)
+        t.join()
+        assert item == "hello"
+
+
+class TestQueueThreadSafety:
+
+    def test_concurrent_put_get(self):
+        q = Queue()
+        results = []
+        lock = threading.Lock()
+
+        def producer(start, end):
+            for i in range(start, end):
+                q.put(i)
+
+        def consumer(count):
+            local_results = []
+            for _ in range(count):
+                local_results.append(q.get(timeout=5.0))
+            with lock:
+                results.extend(local_results)
+
+        producers = [threading.Thread(target=producer, args=(i * 250, (i + 1) * 250)) for i in range(4)]
+        consumers = [threading.Thread(target=consumer, args=(250,)) for i in range(4)]
+
+        for t in producers + consumers:
+            t.start()
+        for t in producers + consumers:
+            t.join(timeout=10)
+
+        assert sorted(results) == list(range(1000))
+
+    def test_bounded_queue_blocks_producer(self):
+        q = Queue(maxsize=1)
+        q.put("first")
+        put_done = threading.Event()
+
+        def delayed_get():
+            time.sleep(0.1)
+            q.get()
+
+        def blocked_put():
+            q.put("second")
+            put_done.set()
+
+        consumer = threading.Thread(target=delayed_get)
+        producer = threading.Thread(target=blocked_put)
+        consumer.start()
+        producer.start()
+        producer.join(timeout=5)
+        consumer.join(timeout=5)
+
+        assert put_done.is_set()
+        assert q.get() == "second"
+
+    def test_consumer_blocks_until_producer(self):
+        q = Queue()
+        result = []
+
+        def delayed_put():
+            time.sleep(0.1)
+            q.put("hello")
+
+        def blocking_get():
+            item = q.get(timeout=5.0)
+            result.append(item)
+
+        consumer = threading.Thread(target=blocking_get)
+        producer = threading.Thread(target=delayed_put)
+        consumer.start()
+        producer.start()
+        consumer.join(timeout=5)
+        producer.join(timeout=5)
+
+        assert result == ["hello"]
+
+
+class TestQueueTaskDoneJoin:
+
+    def test_task_done_and_join(self):
+        q = Queue()
+        q.put("a")
+        q.put("b")
+        results = []
+
+        def worker():
+            while True:
+                try:
+                    item = q.get(timeout=0.5)
+                    results.append(item)
+                    q.task_done()
+                except QueueEmpty:
+                    break
+
+        t = threading.Thread(target=worker)
+        t.start()
+        q.join(timeout=5.0)
+        t.join(timeout=5)
+
+        assert sorted(results) == ["a", "b"]
+
+    def test_task_done_too_many_raises(self):
+        q = Queue()
+        q.put("a")
+        q.get()
+        q.task_done()
+        with pytest.raises(ValueError):
+            q.task_done()
+
+
+class TestQueueImport:
+
+    def test_import_from_turboapi(self):
+        from turboapi import Queue
+        q = Queue()
+        q.put("test")
+        assert q.get() == "test"
+
+    def test_import_exceptions(self):
+        from turboapi import QueueEmpty, QueueFull
+        assert issubclass(QueueEmpty, Exception)
+        assert issubclass(QueueFull, Exception)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Adds `Queue`, `QueueEmpty`, `QueueFull` - a thread-safe in-memory queue that works from Tokio worker threads where `asyncio.Queue` fails
- Uses `threading.Condition` + `collections.deque` for true thread safety across Python 3.13, 3.13t, and 3.14
- Pure Python implementation - works with or without the Rust extension

## Usage

```python
from turboapi import Queue, QueueEmpty

task_queue = Queue(maxsize=100)

@app.post("/enqueue")
def enqueue(data: dict):
    task_queue.put(data)
    return {"queued": task_queue.qsize()}

@app.get("/dequeue")
def dequeue():
    try:
        item = task_queue.get(timeout=5.0)
        return {"item": item}
    except QueueEmpty:
        return {"error": "timeout"}, 408
```

## API

- `put(item, block=True, timeout=None)` / `put_nowait(item)`
- `get(block=True, timeout=None)` / `get_nowait()`
- `qsize()`, `empty()`, `full()`
- `task_done()`, `join(timeout=None)`

## Test plan

- [x] 20 tests passing: basic ops, non-blocking, timeouts, thread safety, bounded queues, task_done/join