### PR TITLE
fix: support Annotated[Type, Depends(...)] pattern

### DIFF
--- a/python/turboapi/request_handler.py
+++ b/python/turboapi/request_handler.py
@@ -29,15 +29,15 @@ class DependencyResolver:
         Returns:
             Dictionary of resolved dependency values
         """
-        from turboapi.security import Depends
+        from turboapi.security import get_depends
 
         cache = {}
         cleanups = []  # generators to close after request
         resolved = {}
 
         for param_name, param in handler_signature.parameters.items():
-            if isinstance(param.default, Depends):
-                depends = param.default
+            depends = get_depends(param)
+            if depends is not None:
                 dep_fn = depends.dependency
                 if dep_fn is None:
                     continue
@@ -54,7 +54,7 @@ class DependencyResolver:
     @staticmethod
     def _resolve_single(dep_fn, use_cache, context, cache, cleanups):
         """Resolve a single dependency, handling sub-deps, caching, generators."""
-        from turboapi.security import Depends, SecurityBase
+        from turboapi.security import SecurityBase, get_depends
 
         cache_key = id(dep_fn)
         if use_cache and cache_key in cache:
@@ -66,12 +66,11 @@ class DependencyResolver:
             try:
                 sig = inspect.signature(dep_fn)
                 for p_name, p in sig.parameters.items():
-                    if isinstance(p.default, Depends):
-                        sub_dep = p.default
-                        if sub_dep.dependency is not None:
-                            sub_kwargs[p_name] = DependencyResolver._resolve_single(
-                                sub_dep.dependency, sub_dep.use_cache, context, cache, cleanups
-                            )
+                    sub_dep = get_depends(p)
+                    if sub_dep is not None and sub_dep.dependency is not None:
+                        sub_kwargs[p_name] = DependencyResolver._resolve_single(
+                            sub_dep.dependency, sub_dep.use_cache, context, cache, cleanups
+                        )
             except (ValueError, TypeError):
                 pass
 
@@ -305,12 +304,12 @@ class RequestBodyParser:
         params_list = list(handler_signature.parameters.items())
 
         # Filter out Depends/Security parameters — they are resolved separately
-        from turboapi.security import Depends, SecurityBase
+        from turboapi.security import Depends, SecurityBase, get_depends
 
         body_params_list = [
             (name, p)
             for name, p in params_list
-            if not isinstance(p.default, Depends) and not isinstance(p.default, SecurityBase)
+            if not isinstance(p.default, (Depends, SecurityBase)) and get_depends(p) is None
         ]
 
         # PATTERN 1: Single parameter that should receive entire body
@@ -640,7 +639,7 @@ def create_enhanced_handler(original_handler, route_definition):
     from turboapi.datastructures import Header
 
     try:
-        from turboapi.security import Depends, SecurityBase
+        from turboapi.security import Depends, SecurityBase, get_depends
 
         _has_security = True
     except ImportError:
@@ -649,7 +648,7 @@ def create_enhanced_handler(original_handler, route_definition):
         if isinstance(param.default, Header):
             _has_header_params = True
         if _has_security and (
-            isinstance(param.default, Depends) or isinstance(param.default, SecurityBase)
+            isinstance(param.default, (Depends, SecurityBase)) or get_depends(param) is not None
         ):
             _has_dependencies = True
 

--- a/python/turboapi/security.py
+++ b/python/turboapi/security.py
@@ -10,6 +10,7 @@ Includes:
 """
 
 import base64
+import inspect
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -554,6 +555,28 @@ class Depends:
         self.use_cache = use_cache
 
 
+
+def get_depends(param: inspect.Parameter) -> Depends | None:
+    """Extract a Depends instance from a parameter — supports both patterns:
+
+    1. Classic:   def f(db: Session = Depends(get_db))
+    2. Annotated: def f(db: Annotated[Session, Depends(get_db)])
+
+    Returns the Depends instance or None.
+    """
+    # Classic pattern: Depends in default value
+    if isinstance(param.default, Depends):
+        return param.default
+
+    # Annotated pattern: Depends in type metadata
+    ann = param.annotation
+    if ann is inspect.Parameter.empty:
+        return None
+    # Annotated types have __metadata__ with the extra args
+    for metadata in getattr(ann, "__metadata__", ()):
+        if isinstance(metadata, Depends):
+            return metadata
+    return None
 class Security(Depends):
     """
     Security dependency with scopes (compatible with FastAPI).

--- a/python/turboapi/testclient.py
+++ b/python/turboapi/testclient.py
@@ -206,6 +206,26 @@ class TestClient:
             if param.annotation is BackgroundTasks:
                 kwargs[param_name] = BackgroundTasks()
 
+        # Resolve Depends/Annotated[..., Depends(...)] parameters
+        try:
+            from .security import get_depends
+
+            for param_name, param in sig.parameters.items():
+                if param_name in kwargs:
+                    continue
+                dep = get_depends(param)
+                if dep is not None and dep.dependency is not None:
+                    dep_fn = dep.dependency
+                    if inspect.iscoroutinefunction(dep_fn):
+                        try:
+                            kwargs[param_name] = asyncio.run(dep_fn())
+                        except RuntimeError:
+                            kwargs[param_name] = dep_fn()
+                    else:
+                        kwargs[param_name] = dep_fn()
+        except ImportError:
+            pass
+
         # Call handler
         try:
             if inspect.iscoroutinefunction(handler):

--- a/python/turboapi/zig_integration.py
+++ b/python/turboapi/zig_integration.py
@@ -44,10 +44,10 @@ def classify_handler(handler, route) -> tuple[str, dict[str, str], dict]:
 
     # Check for Depends/SecurityBase — forces enhanced path
     try:
-        from .security import Depends, SecurityBase
+        from .security import Depends, SecurityBase, get_depends
 
         for _, param in sig.parameters.items():
-            if isinstance(param.default, (Depends, SecurityBase)):
+            if isinstance(param.default, (Depends, SecurityBase)) or get_depends(param) is not None:
                 has_depends = True
                 break
     except ImportError:

--- a/tests/test_annotated_depends.py
+++ b/tests/test_annotated_depends.py
@@ -1,0 +1,120 @@
+"""Test Annotated[Type, Depends(...)] pattern — issue #51."""
+from typing import Annotated
+
+from turboapi import TurboAPI
+from turboapi.security import Depends, get_depends
+from turboapi.testclient import TestClient
+
+
+def get_db():
+    return {"connection": "fake_db"}
+
+
+def get_current_user():
+    return {"user": "alice"}
+
+
+# Type aliases — the FastAPI-recommended pattern
+DB = Annotated[dict, Depends(get_db)]
+CurrentUser = Annotated[dict, Depends(get_current_user)]
+
+
+# ── get_depends helper tests ────────────────────────────────────────────────
+
+
+def test_get_depends_classic():
+    """Classic pattern: def f(db = Depends(get_db))."""
+    import inspect
+
+    sig = inspect.signature(lambda db=Depends(get_db): None)
+    param = list(sig.parameters.values())[0]
+    dep = get_depends(param)
+    assert dep is not None
+    assert dep.dependency is get_db
+
+
+def test_get_depends_annotated():
+    """Annotated pattern: def f(db: Annotated[dict, Depends(get_db)])."""
+    import inspect
+
+    def handler(db: DB):
+        pass
+
+    sig = inspect.signature(handler)
+    param = list(sig.parameters.values())[0]
+    dep = get_depends(param)
+    assert dep is not None
+    assert dep.dependency is get_db
+
+
+def test_get_depends_none():
+    """No Depends at all."""
+    import inspect
+
+    sig = inspect.signature(lambda x: None)
+    param = list(sig.parameters.values())[0]
+    dep = get_depends(param)
+    assert dep is None
+
+
+# ── Integration: Annotated Depends resolves in handlers ──────────────────────
+
+
+def test_annotated_depends_handler():
+    """Handler with Annotated[Type, Depends(...)] should receive resolved value."""
+    app = TurboAPI(title="test")
+
+    @app.get("/items")
+    def read_items(db: DB):
+        return {"db": db}
+
+    client = TestClient(app)
+    resp = client.get("/items")
+    assert resp.status_code == 200
+    assert resp.json()["db"] == {"connection": "fake_db"}
+
+
+def test_annotated_depends_multiple():
+    """Multiple Annotated Depends in same handler."""
+    app = TurboAPI(title="test")
+
+    @app.get("/me")
+    def read_me(db: DB, user: CurrentUser):
+        return {"db": db, "user": user}
+
+    client = TestClient(app)
+    resp = client.get("/me")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["db"] == {"connection": "fake_db"}
+    assert data["user"] == {"user": "alice"}
+
+
+def test_annotated_depends_mixed():
+    """Mix of classic Depends and Annotated Depends."""
+    app = TurboAPI(title="test")
+
+    @app.get("/mixed")
+    def mixed(db: DB, user: dict = Depends(get_current_user)):
+        return {"db": db, "user": user}
+
+    client = TestClient(app)
+    resp = client.get("/mixed")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["db"] == {"connection": "fake_db"}
+    assert data["user"] == {"user": "alice"}
+
+
+def test_classic_depends_still_works():
+    """Classic pattern must not regress."""
+    app = TurboAPI(title="test")
+
+    @app.get("/classic")
+    def classic(db: dict = Depends(get_db)):
+        return {"db": db}
+
+    client = TestClient(app)
+    resp = client.get("/classic")
+    assert resp.status_code == 200
+    assert resp.json()["db"] == {"connection": "fake_db"}


### PR DESCRIPTION
## Summary

Fixes #51 — `Annotated[Type, Depends(...)]` type aliases now work as expected. This is FastAPI's recommended pattern for DI:

```python
DB = Annotated[Session, Depends(get_db)]

@router.get("/items")
async def read_items(db: DB):  # ✅ Now works
    ...
```

### Root cause

TurboAPI only checked `param.default` for `Depends` instances. The `Annotated[T, Depends(...)]` pattern stores the dependency in the type annotation's `__metadata__`, not the default value.

### Fix

New `get_depends(param)` helper in `security.py` that checks both:
1. `param.default` (classic pattern)
2. `param.annotation.__metadata__` (Annotated pattern)

Updated all 5 sites that resolve dependencies + TestClient.

## Test plan

- [x] 7 new tests in `test_annotated_depends.py` — all pass
- [x] Classic `Depends()` pattern still works (no regression)
- [x] Mixed patterns (classic + Annotated) in same handler work
- [x] Multiple Annotated Depends in same handler work
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)