### PR TITLE
feat: Claude Code skills for TurboAPI development

### DIFF
--- a/.claude/skills/turbo-benchmark/SKILL.md
+++ b/.claude/skills/turbo-benchmark/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: turbo-benchmark
+description: Run performance benchmarks for TurboAPI. Use when testing performance, checking for regressions, or comparing against FastAPI.
+disable-model-invocation: true
+argument-hint: [http|db|all]
+---
+
+# Run TurboAPI Benchmarks
+
+## Steps
+
+1. **Determine benchmark type**: `$ARGUMENTS[0]` — `http` (default), `db`, or `all`
+2. **Build turbonet**: Run `uv run --python 3.14t python zig/build_turbonet.py --install --release`
+3. **Run the benchmark**
+
+## HTTP benchmark (TurboAPI vs FastAPI)
+
+```bash
+uv run --python 3.14t python benchmarks/turboapi_vs_fastapi.py --duration 10 --threads 4 --connections 100
+```
+
+Requires: `wrk` installed (`brew install wrk` or `apt install wrk`)
+
+## DB benchmark (pg.zig vs SQLAlchemy)
+
+Requires a running Postgres instance:
+
+```bash
+# Start Postgres
+docker run -d --name bench-pg -p 5432:5432 \
+  -e POSTGRES_USER=turbo -e POSTGRES_PASSWORD=turbo -e POSTGRES_DB=turbotest \
+  postgres:18-alpine
+
+# Wait and seed
+sleep 3
+docker exec bench-pg psql -U turbo -d turbotest -c "
+  CREATE TABLE IF NOT EXISTS users (id SERIAL PRIMARY KEY, name TEXT, email TEXT, age INTEGER);
+  INSERT INTO users (name,email,age) SELECT 'user_' || i, 'user' || i || '@test.com', 20+(i%50) FROM generate_series(1,100) AS s(i);
+"
+
+# Run benchmark
+uv run --python 3.14t python benchmarks/db_bench_ci.py
+
+# Cleanup
+docker stop bench-pg && docker rm bench-pg
+```
+
+## Expected numbers (Apple Silicon M3 Pro)
+
+| Endpoint | TurboAPI | FastAPI | Speedup |
+|----------|----------|---------|---------|
+| GET /health (no DB) | ~128k req/s | ~6k req/s | 20x |
+| GET /users/1 (cached DB) | ~128k req/s | ~934 req/s | 107x |
+| GET /items/{id} (params) | ~143k req/s | ~8.6k req/s | 16x |
+| POST /items (model) | ~124k req/s | ~8.2k req/s | 15x |
+
+## Save results
+
+Benchmark results are saved as JSON artifacts in CI. Check `.github/workflows/benchmark.yml` and `.github/workflows/db-benchmark.yml`.

--- a/.claude/skills/turbo-build/SKILL.md
+++ b/.claude/skills/turbo-build/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: turbo-build
+description: Build the TurboAPI Zig native backend. Use when the turbonet extension needs to be recompiled, after changing Zig source files, or when seeing "Native core not available".
+disable-model-invocation: true
+argument-hint: [--release]
+---
+
+# Build TurboAPI Zig Backend
+
+## Steps
+
+1. **Build turbonet**:
+
+```bash
+uv run --python 3.14t python zig/build_turbonet.py --install $ARGUMENTS
+```
+
+2. **Verify the build**:
+
+```bash
+uv run --python 3.14t python -c "from turboapi import turbonet; print(turbonet.hello())"
+```
+
+## Common issues
+
+- **"Native core not available"**: The turbonet `.so` isn't built or is built for a different Python version. Rebuild with the command above.
+- **dhi hash mismatch**: Run `cd zig && zig fetch --save "https://github.com/justrach/dhi/archive/refs/heads/main.tar.gz"` to update the hash.
+- **Missing Python headers**: Ensure Python 3.14t is installed: `uv python install 3.14t`
+- **Missing Zig**: Install Zig 0.15+: `brew install zig` or download from ziglang.org
+
+## Build modes
+
+- `--install`: Copy the built `.so` into `python/turboapi/` (required for dev)
+- `--release`: Build with ReleaseFast optimizations (for benchmarks/production)
+- No flags: Build only, don't install (for compile checking)
+
+## What gets built
+
+`zig/build_turbonet.py` auto-detects:
+- Python version and include path
+- Free-threaded status (3.14t vs 3.14)
+- dhi dependency (fetched via `build.zig.zon`)
+- pg.zig dependency (fetched via `build.zig.zon`)
+
+Output: `python/turboapi/turbonet.{suffix}.so`

--- a/.claude/skills/turbo-db-route/SKILL.md
+++ b/.claude/skills/turbo-db-route/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: turbo-db-route
+description: Scaffold a Zig-native database route using pg.zig. Use when adding database-backed CRUD endpoints, creating db_get/db_post/db_list/db_delete routes, or writing custom SQL queries with db_query.
+argument-hint: <table-name> [crud|query]
+---
+
+# Scaffold a Zig-Native DB Route
+
+Create database routes that execute entirely in Zig — no Python, no GIL.
+
+## Steps
+
+1. **Determine the table**: Use `$ARGUMENTS[0]` as the table name
+2. **Determine the mode**: `$ARGUMENTS[1]` — `crud` (default) for auto-generated CRUD, or `query` for custom SQL
+3. **Read the existing db route API**: Check `python/turboapi/zig_integration.py` for `db_get`, `db_post`, `db_list`, `db_delete`, `db_query`
+4. **Ensure `configure_db` is called** before any db routes
+
+## CRUD mode (auto-generated SQL)
+
+```python
+from turboapi import TurboAPI
+from dhi import BaseModel, Field
+
+app = TurboAPI()
+app.configure_db("postgres://user:pass@localhost/mydb", pool_size=16)
+
+class {Resource}(BaseModel):
+    name: str = Field(min_length=1, max_length=100)
+    # add fields matching table columns
+
+@app.db_get("/{table}/{{{table}_id}}", table="{table}", pk="id")
+def get_{resource}(): pass
+
+@app.db_list("/{table}", table="{table}")
+def list_{table}(): pass
+
+@app.db_post("/{table}", table="{table}", model={Resource})
+def create_{resource}(): pass
+
+@app.db_delete("/{table}/{{{table}_id}}", table="{table}", pk="id")
+def delete_{resource}(): pass
+```
+
+## Custom query mode (raw SQL)
+
+For complex queries — pgvector, JSONB, full-text search, joins, CTEs:
+
+```python
+@app.db_query("GET", "/search", sql="""
+    SELECT id, title, ts_rank(tsv, plainto_tsquery('english', $1)) AS rank
+    FROM articles WHERE tsv @@ plainto_tsquery('english', $1)
+    ORDER BY rank DESC LIMIT $2
+""", params=["q", "limit"])
+def search(): pass
+
+@app.db_query("GET", "/similar/{item_id}", sql="""
+    SELECT id, name, 1 - (embedding <=> (SELECT embedding FROM items WHERE id = $1)) AS sim
+    FROM items ORDER BY embedding <=> (SELECT embedding FROM items WHERE id = $1) LIMIT $2
+""", params=["item_id", "limit"])
+def similar(): pass
+```
+
+## Performance notes
+
+- **Cached reads**: After first request, GET responses are cached in Zig hashmap (~128k req/s)
+- **Writes invalidate cache**: POST/DELETE auto-clear the cache
+- **Zero Python**: The entire request cycle (HTTP → validate → query → serialize → respond) runs in Zig
+- **Parameterized queries**: All values go through `$N` placeholders — SQL injection safe
+- **Table/column validation**: Names validated at registration time (alphanumeric + underscore only)

--- a/.claude/skills/turbo-route/SKILL.md
+++ b/.claude/skills/turbo-route/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: turbo-route
+description: Scaffold a new TurboAPI route with handler, model, and tests. Use when adding a new API endpoint, creating a new route, or scaffolding CRUD for a resource.
+argument-hint: <resource-name> [GET|POST|PUT|DELETE]
+---
+
+# Scaffold a TurboAPI Route
+
+Create a new route for the TurboAPI application based on the resource name and HTTP method.
+
+## Steps
+
+1. **Determine the resource**: Use `$ARGUMENTS[0]` as the resource name (e.g., `users`, `items`, `orders`)
+2. **Determine the method**: Use `$ARGUMENTS[1]` if provided, otherwise scaffold all CRUD methods (GET, POST, PUT, DELETE)
+3. **Check existing routes**: Read `python/turboapi/zig_integration.py` to understand the current route registration pattern
+4. **Create the model**: If it's a POST/PUT route, create a dhi BaseModel for the request body
+
+## Template
+
+For each route, generate code following this pattern:
+
+```python
+from turboapi import TurboAPI
+from dhi import BaseModel, Field
+
+app = TurboAPI()
+
+class {Resource}(BaseModel):
+    # fields based on resource name
+    name: str = Field(min_length=1, max_length=100)
+
+@app.get("/{resource_plural}")
+def list_{resource_plural}():
+    return {"{resource_plural}": []}
+
+@app.get("/{resource_plural}/{{{resource}_id}}")
+def get_{resource}({resource}_id: int):
+    return {"{resource}_id": {resource}_id}
+
+@app.post("/{resource_plural}")
+def create_{resource}({resource}: {Resource}):
+    return {"{resource}": {resource}.model_dump(), "created": True}
+
+@app.delete("/{resource_plural}/{{{resource}_id}}")
+def delete_{resource}({resource}_id: int):
+    return {"deleted": True}
+```
+
+## Also generate a test file
+
+Create `tests/test_{resource_plural}.py` with TestClient-based tests for each endpoint. Include both success and error cases.
+
+## Handler classification
+
+When creating routes, note which Zig dispatch path they'll use:
+- No params, sync → `simple_sync_noargs` (fastest, cached)
+- Path/query params, sync → `simple_sync` (vectorcall)
+- Body with dhi model → `model_sync` (Zig-native validation)
+- `Depends()` or middleware → `enhanced` (full Python)

--- a/.claude/skills/turbo-test/SKILL.md
+++ b/.claude/skills/turbo-test/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: turbo-test
+description: Run TurboAPI tests. Use when running tests, checking for regressions, or verifying changes.
+disable-model-invocation: true
+argument-hint: [file-or-pattern]
+---
+
+# Run TurboAPI Tests
+
+## Steps
+
+1. **Determine scope**: If `$ARGUMENTS` is provided, run only matching tests. Otherwise run the full suite.
+
+2. **Run tests**:
+
+```bash
+# Full suite
+uv run --python 3.14t python -m pytest tests/ -p no:anchorpy \
+  --deselect tests/test_fastapi_parity.py::TestWebSocket -v
+
+# Specific file
+uv run --python 3.14t python -m pytest tests/$ARGUMENTS -v
+
+# Specific test
+uv run --python 3.14t python -m pytest tests/ -k "$ARGUMENTS" -v
+```
+
+3. **Run Zig unit tests** (if Zig files changed):
+
+```bash
+cd zig && zig build test
+```
+
+4. **Run continuous fuzzing** (if security-sensitive changes):
+
+```bash
+cd zig && zig build test --fuzz
+```
+
+## Known exclusions
+
+- **WebSocket tests** (`TestWebSocket`) — pre-existing failure, always deselect
+- **anchorpy plugin** — causes import error, disable with `-p no:anchorpy`
+
+## Test categories
+
+| File | What it tests |
+|------|--------------|
+| `test_fastapi_parity.py` | FastAPI compatibility (275+ tests) |
+| `test_security_audit_fixes.py` | Security fixes (rate limiting, CORS, etc.) |
+| `test_annotated_depends.py` | Annotated[Type, Depends(...)] pattern |
+| `test_perf_callnoargs_tupleabi.py` | Handler classification + fast paths |
+| `test_query_and_headers.py` | Query params, headers, body parsing |
+
+## Quick smoke test
+
+```bash
+uv run --python 3.14t python -c "
+from turboapi import TurboAPI
+app = TurboAPI()
+@app.get('/')
+def hello(): return {'ok': True}
+from turboapi.testclient import TestClient
+c = TestClient(app)
+assert c.get('/').status_code == 200
+print('OK')
+"
+```


### PR DESCRIPTION
## Summary

5 Claude Code skills for TurboAPI development, following the [Agent Skills](https://agentskills.io) standard.

### Skills

| Skill | Trigger | What it does |
|-------|---------|-------------|
| `/turbo-route <name>` | Manual or auto | Scaffold API routes with handlers, dhi models, and tests |
| `/turbo-db-route <table>` | Manual or auto | Scaffold Zig-native pg.zig DB routes (CRUD + custom SQL) |
| `/turbo-benchmark` | Manual only | Run HTTP and DB benchmarks, shows expected numbers |
| `/turbo-build` | Manual only | Build Zig native backend with troubleshooting guide |
| `/turbo-test` | Manual only | Run Python tests, Zig tests, fuzzing |

### How they work

- Skills live in `.claude/skills/<name>/SKILL.md`
- `/turbo-route` and `/turbo-db-route` can be auto-triggered by Claude when you ask to "add an endpoint" or "create a db route"
- `/turbo-build`, `/turbo-test`, `/turbo-benchmark` are manual-only (`disable-model-invocation: true`) since they have side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)