### PR TITLE
v1.0.17: raw pg.zig queries, LRU cache, pool rotation, pipelining

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboapi"
-version = "1.0.16"
+version = "1.0.17"
 description = "FastAPI-compatible web framework with Zig HTTP core — 20x faster with Python 3.14 free-threading"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/python/turbopg/client.py
+++ b/python/turbopg/client.py
@@ -110,7 +110,12 @@ class Database:
         return self._execute_fallback(sql, params or [])
 
     def _query_native(self, sql: str, params: list) -> list[dict]:
-        """Query via Zig-native pg.zig or Python fallback."""
+        """Query via Zig-native pg.zig directly (no HTTP)."""
+        if self._native and hasattr(self._native, "_db_query_raw"):
+            import json
+            params_json = json.dumps([str(p) for p in params])
+            result_json = self._native._db_query_raw(sql, params_json)
+            return json.loads(result_json)
         if self._fallback_engine:
             return self._query_fallback(sql, params)
         raise NotImplementedError(

--- a/python/turbopg/client.py
+++ b/python/turbopg/client.py
@@ -34,17 +34,19 @@ class Database:
         self._connect()
 
     def _connect(self):
-        """Initialize connection — tries Zig native, falls back to psycopg2/psycopg."""
+        """Initialize connection. Checks for Zig native raw query path first."""
         self._native = None
+        self._native_raw = False
         self._fallback_engine = None
 
-        # Try Zig native pool
+        # Try Zig native pool + raw query path
         try:
             from turboapi import turbonet
 
             if hasattr(turbonet, "_db_configure"):
                 turbonet._db_configure(self.conn_string, self.pool_size)
                 self._native = turbonet
+                self._native_raw = hasattr(turbonet, "_db_query_raw")
         except (ImportError, Exception):
             pass
 
@@ -111,7 +113,7 @@ class Database:
 
     def _query_native(self, sql: str, params: list) -> list[dict]:
         """Query via Zig-native pg.zig directly (no HTTP)."""
-        if self._native and hasattr(self._native, "_db_query_raw"):
+        if self._native_raw:
             import json
             params_json = json.dumps([str(p) for p in params])
             result_json = self._native._db_query_raw(sql, params_json)

--- a/tests/test_turbopg.py
+++ b/tests/test_turbopg.py
@@ -143,6 +143,7 @@ def test_query_no_backend_raises():
 
     db = object.__new__(Database)
     db._native = True  # pretend native exists
+    db._native_raw = False  # no raw query path
     db._fallback_engine = None  # but no fallback
 
     with pytest.raises(NotImplementedError, match="psycopg2-binary"):
@@ -154,6 +155,7 @@ def test_execute_no_backend_raises():
 
     db = object.__new__(Database)
     db._native = True
+    db._native_raw = False
     db._fallback_engine = None
 
     with pytest.raises(NotImplementedError, match="psycopg2-binary"):

--- a/zig/build.zig.zon
+++ b/zig/build.zig.zon
@@ -7,7 +7,7 @@
             .hash = "dhi-0.1.0-Fz3bn0-FAwAv-biejuK3wnjN1A9D3F-NYLFa7fIVu7Ei",
         },
         .pg = .{
-            .url = "git+https://github.com/justrach/pg.zig?ref=perf/zero-copy-and-lru-cache#bcf5b69eef25a8a48079cd9c1a7debfb7cba057a",
+            .url = "git+https://github.com/justrach/pg.zig?ref=master#f243c5c7f3e12d485cf4fccd0eba60a19e50310c",
             .hash = "pg-0.0.0-Wp_7gbDFBgBYPU_h28EuQi8hgVZLw5AWH6YNuIdY3LP0",
         },
     },

--- a/zig/build.zig.zon
+++ b/zig/build.zig.zon
@@ -7,8 +7,8 @@
             .hash = "dhi-0.1.0-Fz3bn0-FAwAv-biejuK3wnjN1A9D3F-NYLFa7fIVu7Ei",
         },
         .pg = .{
-            .url = "git+https://github.com/justrach/pg.zig?ref=master#d4507e4f3b87f49b4f3a0f24181d53fc859c99ed",
-            .hash = "pg-0.0.0-Wp_7gSi0BgBWYviCZkqPrsCXixiHoTOTuQQp33gV5rSO",
+            .url = "git+https://github.com/justrach/pg.zig?ref=perf/zero-copy-and-lru-cache#bcf5b69eef25a8a48079cd9c1a7debfb7cba057a",
+            .hash = "pg-0.0.0-Wp_7gbDFBgBYPU_h28EuQi8hgVZLw5AWH6YNuIdY3LP0",
         },
     },
     .paths = .{""},

--- a/zig/build.zig.zon
+++ b/zig/build.zig.zon
@@ -7,8 +7,8 @@
             .hash = "dhi-0.1.0-Fz3bn0-FAwAv-biejuK3wnjN1A9D3F-NYLFa7fIVu7Ei",
         },
         .pg = .{
-            .url = "git+https://github.com/justrach/pg.zig?ref=master#ce026efad4a24569c473763f80aed71c868973d7",
-            .hash = "pg-0.0.0-Wp_7gd6yBgDtZMrVDmn77u5l0Wi5J39JJ-VgAuoXR0Dy",
+            .url = "git+https://github.com/justrach/pg.zig?ref=master#d4507e4f3b87f49b4f3a0f24181d53fc859c99ed",
+            .hash = "pg-0.0.0-Wp_7gSi0BgBWYviCZkqPrsCXixiHoTOTuQQp33gV5rSO",
         },
     },
     .paths = .{""},

--- a/zig/src/db.zig
+++ b/zig/src/db.zig
@@ -824,3 +824,84 @@ pub fn db_add_route(_: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObje
     std.debug.print("[DB] Registered: {s} {s} -> {s}.{s} ({s})\n", .{ method_s, path_s, table_s, if (pk_col) |pk| pk else "*", op_s });
     return py.pyNone();
 }
+
+
+// ── Raw query API (no HTTP, direct pg.zig from Python) ──────────────────────
+// Called as: turbonet._db_query_raw(sql, params_json) -> json_string
+// This bypasses the HTTP server entirely for standalone TurboPG usage.
+
+pub fn db_query_raw(_: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    var sql_ptr: [*c]const u8 = null;
+    var params_ptr: [*c]const u8 = null;
+    if (c.PyArg_ParseTuple(args, "ss", &sql_ptr, &params_ptr) == 0) return null;
+
+    const sql = std.mem.span(sql_ptr);
+    const params_json = std.mem.span(params_ptr);
+
+    if (db_pool == null) {
+        py.setError("Database not configured. Call configure_db() first.", .{});
+        return null;
+    }
+
+    // Parse params JSON array: ["val1", "val2", ...]
+    var param_values: [16][]const u8 = undefined;
+    var param_count: usize = 0;
+
+    if (params_json.len > 2) {
+        var i: usize = 1; // skip opening [
+        while (i < params_json.len and param_count < 16) {
+            while (i < params_json.len and (params_json[i] == ' ' or params_json[i] == ',' or params_json[i] == '\n')) : (i += 1) {}
+            if (i >= params_json.len or params_json[i] == ']') break;
+
+            if (params_json[i] == '"') {
+                i += 1;
+                const start = i;
+                while (i < params_json.len and params_json[i] != '"') : (i += 1) {}
+                param_values[param_count] = params_json[start..i];
+                param_count += 1;
+                i += 1;
+            } else {
+                const start = i;
+                while (i < params_json.len and params_json[i] != ',' and params_json[i] != ']' and params_json[i] != ' ') : (i += 1) {}
+                param_values[param_count] = params_json[start..i];
+                param_count += 1;
+            }
+        }
+    }
+
+    const conn = acquireConn() orelse {
+        py.setError("Failed to acquire database connection", .{});
+        return null;
+    };
+    defer releaseConn(conn);
+
+    const result = execWithParams(conn, sql, param_values[0..param_count], null) orelse {
+        py.setError("Query failed: {s}", .{sql});
+        return null;
+    };
+    defer result.deinit();
+
+    const col_names = result.column_names;
+
+    // Serialize all rows as JSON array
+    var json_buf: [1024 * 1024]u8 = undefined;
+    var pos: usize = 0;
+    json_buf[pos] = '[';
+    pos += 1;
+
+    var row_count: usize = 0;
+    while (result.next() catch null) |row| {
+        if (row_count > 0) {
+            json_buf[pos] = ',';
+            pos += 1;
+        }
+        const row_json = serializeRow(row, col_names, json_buf[pos..]) catch break;
+        pos += row_json.len;
+        row_count += 1;
+    }
+
+    json_buf[pos] = ']';
+    pos += 1;
+
+    return c.PyUnicode_FromStringAndSize(@ptrCast(&json_buf), @intCast(pos));
+}

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -45,7 +45,7 @@ var methods = [_]py.PyMethodDef{
     // DB functions
     .{ .ml_name = "_db_configure", .ml_meth = @ptrCast(&db.db_configure), .ml_flags = c.METH_VARARGS, .ml_doc = null },
     .{ .ml_name = "_db_add_route", .ml_meth = @ptrCast(&db.db_add_route), .ml_flags = c.METH_VARARGS, .ml_doc = null },
-    // sentinel
+    .{ .ml_name = "_db_query_raw", .ml_meth = @ptrCast(&db.db_query_raw), .ml_flags = c.METH_VARARGS, .ml_doc = null },
     .{ .ml_name = null, .ml_meth = null, .ml_flags = 0, .ml_doc = null },
 };
 


### PR DESCRIPTION
## Summary
- Raw pg.zig query path from Python (no HTTP overhead) - closes #60
- Boolean param encoding fix in pg.zig fork - closes #59
- Bounded LRU stmt cache (256 max)
- Pool connection rotation (max_queries + max_lifetime)
- Query pipelining (batch queries in one round trip)

## Benchmarks
- Native path: 1.25x faster than asyncpg (10k concurrent queries)
- HTTP path: 151k+ req/s (no regression from main)

## Test plan
- [x] All 317 tests pass
- [x] Pre-commit hooks pass (TurboPG + Annotated Depends + Security)
- [x] HTTP benchmark regression check
- [x] Native vs asyncpg concurrent benchmark