### PR TITLE
hotfix: verified middleware/auth fixes and 1.0.20 release prep

### DIFF
--- a/.codex/skills/hotfix-adversary/SKILL.md
+++ b/.codex/skills/hotfix-adversary/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: hotfix-adversary
+description: Use when preparing or reviewing a hotfix/bugfix branch. Requires an exact repro or focused regression test, an adversarial review pass, and explicit verification evidence before opening or merging the PR.
+---
+
+# Hotfix Adversary
+
+Use this skill on any branch named `hotfix/*` or `bugfix/*`, or when the user asks for a bug-fix release or emergency patch.
+
+## Required workflow
+
+1. Identify the exact bug claim.
+2. Add or update one focused regression test or exact repro.
+3. Run the smallest relevant test command first.
+4. Run an adversarial review pass with gitagent before merge.
+5. Only then open or update the PR.
+
+## Adversarial review
+
+Use any available gitagent reviewer or reviewer-fixer workflow in the current environment.
+Examples, when available, include a dedicated reviewer pass, a review-fix loop, or a reviewer-oriented task preset.
+
+The adversarial pass should look for:
+
+- false positives where the “fix” only changes tests
+- hidden regressions in adjacent request/response paths
+- incomplete edge handling
+- versioning or release metadata drift
+- benchmark or verification claims that are not supported by the test evidence
+
+## Hotfix acceptance bar
+
+Do not call the hotfix done unless all are true:
+
+- the exact repro now passes
+- the adversarial review found no remaining blocking issue, or its findings were fixed and rechecked
+- the PR body states what changed, how it was verified, and what was intentionally not changed
+
+## Keep it narrow
+
+- Do not bundle unrelated refactors.
+- Do not include unrelated dirty-worktree files in the branch.
+- Prefer a patch version bump only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to TurboAPI are documented here.
 
+## [1.0.20] — 2026-03-25
+
+### Bug Fixes
+
+- Restored gzip middleware header/body passthrough on the Zig runtime so `Content-Encoding: gzip` and compressed bytes survive the round trip.
+- Restored implicit header-name extraction for plain handler params such as `authorization` and `x_request_id`.
+- Replaced password helper placeholders with working stdlib PBKDF2 hashing and verification helpers, exposed as `get_password_hash()` and `verify_password_hash()` at the package root without changing the existing JWT-oriented `verify_password()` export.
+
+### Verification
+
+- Added exact repro coverage for issues [#96](https://github.com/justrach/turboAPI/issues/96), [#97](https://github.com/justrach/turboAPI/issues/97), and [#98](https://github.com/justrach/turboAPI/issues/98) in `tests/test_verified_audit_items.py`.
+
 ## [1.0.01] — 2026-03-19
 
 ### Performance (47k → 150k req/s)
@@ -27,7 +39,7 @@ All notable changes to TurboAPI are documented here.
   - `middleware.py`: `threading.Lock` on rate limiter dict (data race)
   - `middleware.py`: Prefer `X-Real-IP` over `X-Forwarded-For`
   - `middleware.py`: `ValueError` on CORS wildcard + credentials
-  - `security.py`: `NotImplementedError` for password hash placeholders
+  - `security.py`: password hash placeholder issue was identified here; the working built-in hash/verify implementation shipped later in `1.0.20`
   - `server.zig`: `handler_tag` set in all route registration functions
 - **Slowloris protection** — `SO_RCVTIMEO` 30s on accepted sockets (`dee1019`)
 - **Fuzz tests** for HTTP parser, router, JSON validator, URL decoder (`2024239`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboapi"
-version = "1.0.19"
+version = "1.0.20"
 description = "FastAPI-compatible web framework with Zig HTTP core — 20x faster with Python 3.14 free-threading"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="turboapi",
-    version="1.0.19",
+    version="1.0.20",
     description="A high-performance Python web framework for the no-GIL era",
     long_description=open("../README.md").read(),
     long_description_content_type="text/markdown",

--- a/python/turboapi/__init__.py
+++ b/python/turboapi/__init__.py
@@ -81,6 +81,10 @@ from .security import (
     OAuth2PasswordBearer,
     Security,
     SecurityScopes,
+    get_password_hash,
+)
+from .security import (
+    verify_password as verify_password_hash,
 )
 
 # SSE (Server-Sent Events)
@@ -92,7 +96,7 @@ from .version_check import check_free_threading_support, get_python_threading_in
 # WebSocket
 from .websockets import WebSocket, WebSocketDisconnect
 
-__version__ = "1.0.19"
+__version__ = "1.0.20"
 __all__ = [
     # Core
     "TurboAPI",
@@ -162,5 +166,7 @@ __all__ = [
     "create_refresh_token",
     "decode_token",
     "hash_password",
+    "get_password_hash",
     "verify_password",
+    "verify_password_hash",
 ]

--- a/python/turboapi/request_handler.py
+++ b/python/turboapi/request_handler.py
@@ -778,12 +778,14 @@ def create_enhanced_handler(original_handler, route_definition):
                                         pass
                             parsed_params.update(params)
 
-                # 3. Parse headers (only if handler needs them)
-                if _has_header_params:
-                    headers_dict = kwargs.get("headers", {})
-                    if headers_dict:
-                        header_params = HeaderParser.parse_headers(headers_dict, sig)
-                        parsed_params.update(header_params)
+                # 3. Parse headers (always, for both explicit Header() and implicit name-matched params).
+                # Use non-overriding merge so query/path params resolved above take precedence.
+                headers_dict = kwargs.get("headers", {})
+                if headers_dict:
+                    header_params = HeaderParser.parse_headers(headers_dict, sig)
+                    for _hk, _hv in header_params.items():
+                        if _hk not in parsed_params:
+                            parsed_params[_hk] = _hv
 
                 # 4. Parse request body (JSON)
                 body_data = kwargs.get("body", b"")

--- a/python/turboapi/request_handler.py
+++ b/python/turboapi/request_handler.py
@@ -635,8 +635,6 @@ def create_enhanced_handler(original_handler, route_definition):
     # Pre-check which features this handler needs
     _param_names = set(sig.parameters.keys())
     _has_dependencies = False
-    _has_header_params = False
-    from turboapi.datastructures import Header
 
     try:
         from turboapi.security import Depends, SecurityBase, get_depends
@@ -645,8 +643,6 @@ def create_enhanced_handler(original_handler, route_definition):
     except ImportError:
         _has_security = False
     for pname, param in sig.parameters.items():
-        if isinstance(param.default, Header):
-            _has_header_params = True
         if _has_security and (
             isinstance(param.default, (Depends, SecurityBase)) or get_depends(param) is not None
         ):
@@ -676,12 +672,14 @@ def create_enhanced_handler(original_handler, route_definition):
                         )
                         parsed_params.update(path_params)
 
-                # 3. Parse headers
-                if "headers" in kwargs:
-                    headers_dict = kwargs.get("headers", {})
-                    if headers_dict:
-                        header_params = HeaderParser.parse_headers(headers_dict, sig)
-                        parsed_params.update(header_params)
+                # 3. Parse headers for explicit Header() params and implicit
+                # underscore-to-dash name matches. Do not override query/path.
+                headers_dict = kwargs.get("headers", {})
+                if headers_dict:
+                    header_params = HeaderParser.parse_headers(headers_dict, sig)
+                    for _hk, _hv in header_params.items():
+                        if _hk not in parsed_params:
+                            parsed_params[_hk] = _hv
 
                 # 4. Parse request body (JSON)
                 if "body" in kwargs:

--- a/python/turboapi/security.py
+++ b/python/turboapi/security.py
@@ -506,32 +506,45 @@ from .exceptions import HTTPException  # noqa: F401, E402
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """
-    Verify a password against a hash.
+    Verify a password against a hash produced by get_password_hash().
 
-    This is a placeholder — install a proper hashing library and replace:
-      - passlib with bcrypt: ``passlib.hash.bcrypt.verify(plain, hashed)``
-      - argon2-cffi: ``argon2.PasswordHasher().verify(hashed, plain)``
+    Uses PBKDF2-HMAC-SHA256 with the salt embedded in the stored hash.
+    Format: ``pbkdf2_sha256$<iterations>$<salt_hex>$<hash_hex>``
     """
-    raise NotImplementedError(
-        "verify_password is not implemented. "
-        "Install passlib[bcrypt] or argon2-cffi and replace this function."
-    )
+    import hashlib
+    import hmac as _hmac
 
-
+    try:
+        tag, iterations_str, salt_hex, stored_hex = hashed_password.split("$")
+    except ValueError:
+        return False
+    if tag != "pbkdf2_sha256":
+        return False
+    try:
+        iterations = int(iterations_str)
+        salt = bytes.fromhex(salt_hex)
+        stored = bytes.fromhex(stored_hex)
+    except (ValueError, TypeError):
+        return False
+    dk = hashlib.pbkdf2_hmac("sha256", plain_password.encode("utf-8"), salt, iterations)
+    return _hmac.compare_digest(dk, stored)
 def get_password_hash(password: str) -> str:
     """
-    Hash a password.
+    Hash a password using PBKDF2-HMAC-SHA256 with a random 16-byte salt.
 
-    This is a placeholder — install a proper hashing library and replace:
-      - passlib with bcrypt: ``passlib.hash.bcrypt.hash(password)``
-      - argon2-cffi: ``argon2.PasswordHasher().hash(password)``
+    Returns a string in the format:
+    ``pbkdf2_sha256$<iterations>$<salt_hex>$<hash_hex>``
+
+    Pure-stdlib implementation — no extra dependencies required.
+    For higher security, consider passlib[bcrypt] or argon2-cffi.
     """
-    raise NotImplementedError(
-        "get_password_hash is not implemented. "
-        "Install passlib[bcrypt] or argon2-cffi and replace this function."
-    )
+    import hashlib
+    import os
 
-
+    iterations = 260_000
+    salt = os.urandom(16)
+    dk = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, iterations)
+    return f"pbkdf2_sha256${iterations}${salt.hex()}${dk.hex()}"
 # ============================================================================
 # Dependency Injection Helper
 # ============================================================================

--- a/python/turboapi/zig_integration.py
+++ b/python/turboapi/zig_integration.py
@@ -602,6 +602,11 @@ class ZigIntegratedTurboAPI(TurboAPI):
         middleware_instances = self._middleware_instances
 
         def middleware_wrapped_handler(**kwargs):
+            def _sanitize_header_component(value: str) -> str:
+                # Prevent CRLF injection when extra headers are tunneled through
+                # the content_type field for the Zig response writer.
+                return value.replace("\r", "").replace("\n", "")
+
             # Normalize header names to lowercase so middleware can use case-insensitive
             # dict.get("accept-encoding") lookups regardless of what the Zig HTTP parser
             # preserved (it keeps the original mixed-case from the wire).
@@ -664,13 +669,15 @@ class ZigIntegratedTurboAPI(TurboAPI):
                 base_ct = result.get("content_type") or "application/json"
                 extra_parts = []
                 for hname, hvalue in response.headers.items():
-                    hn_lower = hname.lower()
+                    safe_name = _sanitize_header_component(hname)
+                    safe_value = _sanitize_header_component(str(hvalue))
+                    hn_lower = safe_name.lower()
                     if hn_lower == "content-type":
-                        base_ct = hvalue
+                        base_ct = safe_value
                     elif hn_lower == "content-length":
                         pass  # Zig recalculates from actual body length
                     else:
-                        extra_parts.append(f"{hname}: {hvalue}")
+                        extra_parts.append(f"{safe_name}: {safe_value}")
                 if extra_parts:
                     result["content_type"] = base_ct + "\r\n" + "\r\n".join(extra_parts)
                 else:

--- a/python/turboapi/zig_integration.py
+++ b/python/turboapi/zig_integration.py
@@ -602,10 +602,15 @@ class ZigIntegratedTurboAPI(TurboAPI):
         middleware_instances = self._middleware_instances
 
         def middleware_wrapped_handler(**kwargs):
+            # Normalize header names to lowercase so middleware can use case-insensitive
+            # dict.get("accept-encoding") lookups regardless of what the Zig HTTP parser
+            # preserved (it keeps the original mixed-case from the wire).
+            raw_headers = kwargs.get("headers", {})
+            normalized_headers = {k.lower(): v for k, v in raw_headers.items()}
             request = Request(
                 method=kwargs.get("method", ""),
                 path=kwargs.get("path", ""),
-                headers=kwargs.get("headers", {}),
+                headers=normalized_headers,
                 body=kwargs.get("body", b""),
                 query_string=kwargs.get("query_string", ""),
                 path_params=kwargs.get("path_params", {}),
@@ -649,10 +654,32 @@ class ZigIntegratedTurboAPI(TurboAPI):
             for mw in reversed(middleware_instances):
                 response = mw.after_request(request, response)
 
-            # Merge middleware-added headers back
+            # Merge middleware-added headers and body back into the result dict.
+            # Extra headers (e.g. Content-Encoding: gzip) are injected into the
+            # content_type string via \r\n so that sendResponse() in Zig emits them
+            # verbatim — no Zig-side changes required.
             result["status_code"] = response.status_code
             if response.headers:
-                result["extra_headers"] = response.headers
+                result["extra_headers"] = response.headers  # kept for callers that inspect it
+                base_ct = result.get("content_type") or "application/json"
+                extra_parts = []
+                for hname, hvalue in response.headers.items():
+                    hn_lower = hname.lower()
+                    if hn_lower == "content-type":
+                        base_ct = hvalue
+                    elif hn_lower == "content-length":
+                        pass  # Zig recalculates from actual body length
+                    else:
+                        extra_parts.append(f"{hname}: {hvalue}")
+                if extra_parts:
+                    result["content_type"] = base_ct + "\r\n" + "\r\n".join(extra_parts)
+                else:
+                    result["content_type"] = base_ct
+
+            # Propagate the (possibly compressed/modified) response body.
+            response_body = response.body
+            if response_body:
+                result["content"] = response_body  # bytes — Zig handles via PyBytes_Check
 
             return result
 

--- a/tests/test_middleware_compat.py
+++ b/tests/test_middleware_compat.py
@@ -134,14 +134,12 @@ def gzip_app():
     return f"http://127.0.0.1:{port}"
 
 
-@pytest.mark.xfail(reason="Requires middleware header/body passthrough (PR #55)")
 def test_gzip_middleware_compat(gzip_app):
     """GZip middleware must correctly compress and return 200."""
     r = requests.get(f"{gzip_app}/large", headers={"Accept-Encoding": "gzip"})
     assert r.status_code == 200, r.text
     assert r.headers.get("Content-Encoding") == "gzip"
 
-@pytest.mark.xfail(reason="Requires middleware header/body passthrough (PR #55)")
 def test_gzip_body_is_actually_compressed(gzip_app):
     """The body must actually be gzip-compressed bytes, not original JSON.
     Decompress and verify the data survived the round trip."""

--- a/tests/test_security_audit_fixes.py
+++ b/tests/test_security_audit_fixes.py
@@ -108,21 +108,19 @@ def test_cors_explicit_origin_with_credentials_ok():
 # ── Bug #11: Password hash placeholder ──────────────────────────────────────
 
 def test_get_password_hash_raises():
-    """Bug #11: get_password_hash must NOT return plaintext."""
+    """Bug #11 → fixed: get_password_hash must return a hash, NOT raise and NOT return plaintext."""
     from turboapi.security import get_password_hash
 
-    with pytest.raises(NotImplementedError):
-        get_password_hash("secret123")
-
-
+    hashed = get_password_hash("secret123")
+    assert isinstance(hashed, str) and hashed, "get_password_hash must return a non-empty string"
+    assert hashed != "secret123", "get_password_hash must NOT return plaintext"
 def test_verify_password_raises():
-    """Bug #11: verify_password must NOT do plaintext comparison."""
-    from turboapi.security import verify_password
+    """Bug #11 → fixed: verify_password must verify correctly, NOT raise."""
+    from turboapi.security import get_password_hash, verify_password
 
-    with pytest.raises(NotImplementedError):
-        verify_password("secret123", "secret123")
-
-
+    hashed = get_password_hash("secret123")
+    assert verify_password("secret123", hashed) is True
+    assert verify_password("wrong", hashed) is False
 # ── Bug #5: Port range validation ───────────────────────────────────────────
 # (Zig-side — tested via integration; can't unit test @intCast directly)
 

--- a/tests/test_verified_audit_items.py
+++ b/tests/test_verified_audit_items.py
@@ -121,7 +121,7 @@ def test_verified_password_hashing_helpers():
 
     Repro for https://github.com/justrach/turboAPI/issues/98
     """
-    from turboapi.security import get_password_hash, verify_password
+    from turboapi import get_password_hash, verify_password_hash
 
     password = "correct-horse-battery-staple"
     hashed = get_password_hash(password)
@@ -131,12 +131,12 @@ def test_verified_password_hashing_helpers():
     assert hashed != password, "get_password_hash returned plaintext — no hashing performed"
 
     # Correct password must verify
-    assert verify_password(password, hashed) is True, (
+    assert verify_password_hash(password, hashed) is True, (
         "verify_password returned False for the correct password"
     )
 
     # Wrong password must not verify
-    assert verify_password("wrong-password", hashed) is False, (
+    assert verify_password_hash("wrong-password", hashed) is False, (
         "verify_password returned True for a wrong password"
     )
 
@@ -145,5 +145,5 @@ def test_verified_password_hashing_helpers():
     assert hashed != hashed2, "get_password_hash produced identical hashes (missing random salt)"
 
     # Cross-verify: each hash must only accept its own password
-    assert verify_password(password, hashed2) is True
-    assert verify_password("bad", hashed2) is False
+    assert verify_password_hash(password, hashed2) is True
+    assert verify_password_hash("bad", hashed2) is False

--- a/tests/test_verified_audit_items.py
+++ b/tests/test_verified_audit_items.py
@@ -1,0 +1,149 @@
+"""
+Exact repro tests for issues #96, #97, and #98.
+
+Each test is self-contained, starts its own server on a random port,
+and is the sole acceptance criterion for the corresponding issue.
+"""
+
+import socket
+import threading
+import time
+
+import requests
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _start(app, port, timeout: float = 2.5):
+    t = threading.Thread(target=lambda: app.run(host="127.0.0.1", port=port), daemon=True)
+    t.start()
+    time.sleep(timeout)
+
+
+# ── Issue #96 — GZipMiddleware + Zig runtime: Content-Encoding header ────────
+
+
+def test_verified_gzip_passthrough_round_trip():
+    """
+    GZipMiddleware must:
+    1. Set Content-Encoding: gzip on responses larger than minimum_size.
+    2. Return a body that decompresses to the original JSON payload.
+
+    Repro for https://github.com/justrach/turboAPI/issues/96
+    """
+    import os
+
+    os.environ["TURBO_DISABLE_CACHE"] = "1"
+
+    from turboapi import TurboAPI
+    from turboapi.middleware import GZipMiddleware
+
+    app = TurboAPI(title="GZip test")
+    app.add_middleware(GZipMiddleware, minimum_size=10)
+
+    @app.get("/large")
+    def large_response():
+        return {"data": "A" * 1000}
+
+    port = _free_port()
+    _start(app, port)
+
+    r = requests.get(
+        f"http://127.0.0.1:{port}/large",
+        headers={"Accept-Encoding": "gzip"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.headers.get("Content-Encoding") == "gzip", (
+        f"Expected Content-Encoding: gzip, got headers: {dict(r.headers)}"
+    )
+    # requests auto-decompresses; verify round-trip integrity
+    data = r.json()
+    assert len(data["data"]) == 1000, "Body was mangled during gzip round-trip"
+
+
+# ── Issue #97 — Implicit header-name mapping for plain handler params ─────────
+
+
+def test_verified_implicit_header_extraction():
+    """
+    Plain handler params such as `authorization` and `x_request_id` must be
+    populated from request headers via underscore-to-dash name mapping,
+    without requiring explicit Header() markers.
+
+    Uses LoggingMiddleware to route through the enhanced handler path (the path
+    that passes the full headers dict to Python). CORSMiddleware is excluded
+    because the Zig runtime intercepts it natively and leaves _middleware_instances
+    empty, keeping the handler on the vectorcall path that only receives
+    path/query params.
+
+    Repro for https://github.com/justrach/turboAPI/issues/97
+    """
+    import os
+
+    os.environ["TURBO_DISABLE_CACHE"] = "1"
+
+    from turboapi import TurboAPI
+    from turboapi.middleware import LoggingMiddleware
+
+    app = TurboAPI(title="Header test")
+    # LoggingMiddleware is instantiated in _middleware_instances (not intercepted by
+    # Zig native), which forces the handler to use the enhanced (dict-kwargs) path
+    # that passes the full headers dict to Python.
+    app.add_middleware(LoggingMiddleware)
+
+    @app.get("/implicit-headers")
+    def implicit_headers(authorization: str = "missing", x_request_id: str = "missing"):
+        return {"authorization": authorization, "request_id": x_request_id}
+
+    port = _free_port()
+    _start(app, port)
+
+    r = requests.get(
+        f"http://127.0.0.1:{port}/implicit-headers",
+        headers={"Authorization": "Bearer token123", "X-Request-ID": "req-42"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body == {"authorization": "Bearer token123", "request_id": "req-42"}, (
+        f"Implicit header extraction failed: {body}"
+    )
+# ── Issue #98 — Built-in password hashing helpers ────────────────────────────
+
+
+def test_verified_password_hashing_helpers():
+    """
+    turboapi.security.get_password_hash / verify_password must work out of the
+    box without raising NotImplementedError.
+
+    Repro for https://github.com/justrach/turboAPI/issues/98
+    """
+    from turboapi.security import get_password_hash, verify_password
+
+    password = "correct-horse-battery-staple"
+    hashed = get_password_hash(password)
+
+    # Hash must be a non-empty string and must not be the plaintext password
+    assert isinstance(hashed, str) and hashed, "get_password_hash returned empty string"
+    assert hashed != password, "get_password_hash returned plaintext — no hashing performed"
+
+    # Correct password must verify
+    assert verify_password(password, hashed) is True, (
+        "verify_password returned False for the correct password"
+    )
+
+    # Wrong password must not verify
+    assert verify_password("wrong-password", hashed) is False, (
+        "verify_password returned True for a wrong password"
+    )
+
+    # Two hashes of the same password must differ (random salt)
+    hashed2 = get_password_hash(password)
+    assert hashed != hashed2, "get_password_hash produced identical hashes (missing random salt)"
+
+    # Cross-verify: each hash must only accept its own password
+    assert verify_password(password, hashed2) is True
+    assert verify_password("bad", hashed2) is False

--- a/zig/src/server.zig
+++ b/zig/src/server.zig
@@ -1946,15 +1946,21 @@ pub fn sendResponse(stream: std.net.Stream, status: u16, content_type: []const u
         day_secs.getHoursIntoDay(), day_secs.getMinutesIntoHour(), day_secs.getSecondsIntoMinute(),
     }) catch "Thu, 01 Jan 2026 00:00:00 GMT";
 
-    var header_buf: [512]u8 = undefined;
-    const header = std.fmt.bufPrint(&header_buf,
-        "HTTP/1.1 {d} {s}\r\nServer: TurboAPI\r\nDate: {s}\r\nContent-Type: {s}\r\nContent-Length: {d}\r\nConnection: keep-alive",
-        .{ status, statusText(status), date_str, content_type, body.len },
-    ) catch return;
-
     // Assemble: header + cors_headers (pre-rendered, "" if disabled) + \r\n\r\n + body
     const cors = cors_headers; // "" when disabled — zero overhead
     const trailer = "\r\n\r\n";
+    const header_fmt =
+        "HTTP/1.1 {d} {s}\r\nServer: TurboAPI\r\nDate: {s}\r\nContent-Type: {s}\r\nContent-Length: {d}\r\nConnection: keep-alive";
+    const header_args = .{ status, statusText(status), date_str, content_type, body.len };
+    var header_buf: [2048]u8 = undefined;
+    const header = std.fmt.bufPrint(&header_buf, header_fmt, header_args) catch {
+        const fallback =
+            "HTTP/1.1 500 Internal Server Error\r\nServer: TurboAPI\r\nContent-Type: text/plain\r\nContent-Length: 0\r\nConnection: close";
+        stream.writeAll(fallback) catch return;
+        stream.writeAll(trailer) catch return;
+        return;
+    };
+
     const total = header.len + cors.len + trailer.len + body.len;
     if (total <= 4096) {
         var resp_buf: [4096]u8 = undefined;

--- a/zig/src/server.zig
+++ b/zig/src/server.zig
@@ -1824,13 +1824,21 @@ fn callPythonHandler(tstate: ?*anyopaque, entry: HandlerEntry, method: []const u
         }
     }
 
-    // content — json.dumps() if not already a string
+    // content — json.dumps() if not already a string or raw bytes
     var body_slice: []const u8 = "null";
     if (c.PyDict_GetItemString(result, "content")) |content_obj| {
         if (c.PyUnicode_Check(content_obj) != 0) {
-            // Already a string, use directly
+            // Already a string (normal JSON path), use directly
             if (c.PyUnicode_AsUTF8(content_obj)) |cs| {
                 body_slice = std.mem.span(cs);
+            }
+        } else if (c.PyBytes_Check(content_obj) != 0) {
+            // Raw bytes — used by GZipMiddleware and other body-mutating middleware.
+            // Pass through verbatim; the caller already set Content-Encoding etc.
+            var size: c.Py_ssize_t = 0;
+            var buf: [*c]u8 = undefined;
+            if (c.PyBytes_AsStringAndSize(content_obj, @ptrCast(&buf), &size) == 0) {
+                body_slice = buf[0..@intCast(size)];
             }
         } else {
             // Serialize via json.dumps()


### PR DESCRIPTION
## Summary

This hotfix branch restores three verified behaviors and prepares the patch release metadata for `1.0.20`.

### Fixed
- restore gzip middleware header/body passthrough on the Zig runtime
- restore implicit header-name extraction for plain handler params
- replace built-in password helper placeholders with working stdlib PBKDF2 helpers
- preserve the existing root-level JWT `verify_password()` export and expose the new password-hash verifier as `verify_password_hash()`
- harden middleware header passthrough by stripping CR/LF before tunneling extra headers into the Zig response path
- avoid silent response drops in the Zig response writer when the header line formatting overflows the stack buffer

### Release prep
- bump TurboAPI package version to `1.0.20`
- add changelog entry for the hotfix
- add `.codex/skills/hotfix-adversary/SKILL.md` so future `hotfix/*` and `bugfix/*` branches require an exact repro/regression test plus an adversarial review pass before merge

## Verification

Targeted regressions:
```bash
uv run --python 3.14t python -m pytest \
  tests/test_verified_audit_items.py::test_verified_gzip_passthrough_round_trip \
  tests/test_verified_audit_items.py::test_verified_implicit_header_extraction \
  tests/test_verified_audit_items.py::test_verified_password_hashing_helpers \
  tests/test_middleware_compat.py::test_gzip_middleware_compat \
  tests/test_middleware_compat.py::test_gzip_body_is_actually_compressed \
  tests/test_security_audit_fixes.py::test_get_password_hash_raises \
  tests/test_security_audit_fixes.py::test_verify_password_raises \
  -p no:anchorpy -q
```
Result: `7 passed`

Pre-commit on branch commits:
- ruff lint passed
- Zig build passed
- targeted/unit/security/smoke checks passed

Adversarial review:
- gitagent reviewer was run twice on this hotfix branch
- the follow-up fixes addressed the reviewer findings around header passthrough safety and the root-level password helper API surface

## Intentionally not changed
- `uv.lock` was left out of this hotfix because the working-tree lockfile also contains unrelated dependency changes
- unrelated local artifacts and `frontend/dist/turbopg.html` were left out of the branch
