### PR TITLE
fix: refresh dhi hash so release builds can package turbonet

### DIFF
--- a/zig/build.zig.zon
+++ b/zig/build.zig.zon
@@ -4,7 +4,7 @@
     .dependencies = .{
         .dhi = .{
             .url = "https://github.com/justrach/dhi/archive/refs/heads/main.tar.gz",
-            .hash = "dhi-0.1.0-Fz3bn0-FAwAv-biejuK3wnjN1A9D3F-NYLFa7fIVu7Ei",
+            .hash = "dhi-0.1.0-Fz3bnz2GAwD-QDhvUhwzx5RJ5Yu1q_eYivGu0JYlOrcZ",
         },
         .pg = .{
             .url = "git+https://github.com/justrach/pg.zig?ref=master#7605502f24e348c50341cbdf84ac135613d512af",


### PR DESCRIPTION
## Summary

The `v1.0.21` tag/release exposed a stale Zig dependency pin in `zig/build.zig.zon`.

`Build & Publish` was failing in `Build turbonet extension` on every matrix entry with a `hash mismatch` for the `dhi` dependency.

This PR updates the pinned `dhi` hash to the currently fetched package hash and nothing else.

## Files touched

- `zig/build.zig.zon`

## Exact repro

Before the fix, forcing a clean Zig fetch failed with the same hash-mismatch error seen in GitHub Actions:
```bash
TMP=$(mktemp -d) && \
ZIG_GLOBAL_CACHE_DIR="$TMP/global" \
ZIG_LOCAL_CACHE_DIR="$TMP/local" \
python zig/build_turbonet.py --install --release
```

## After

The same command now succeeds with a clean cache.

## Scope notes

- no lockfile changes
- no generated artifacts committed
- no runtime or API behavior changes
- this is a release/build fix only
