### PR TITLE
fix: restore verified Zig runtime gzip/header/password behavior

### DIFF
--- a/python/turboapi/request_handler.py
+++ b/python/turboapi/request_handler.py
@@ -635,9 +635,6 @@ def create_enhanced_handler(original_handler, route_definition):
     # Pre-check which features this handler needs
     _param_names = set(sig.parameters.keys())
     _has_dependencies = False
-    _has_header_params = False
-    from turboapi.datastructures import Header
-
     try:
         from turboapi.security import Depends, SecurityBase, get_depends
 
@@ -645,8 +642,6 @@ def create_enhanced_handler(original_handler, route_definition):
     except ImportError:
         _has_security = False
     for pname, param in sig.parameters.items():
-        if isinstance(param.default, Header):
-            _has_header_params = True
         if _has_security and (
             isinstance(param.default, (Depends, SecurityBase)) or get_depends(param) is not None
         ):
@@ -676,12 +671,14 @@ def create_enhanced_handler(original_handler, route_definition):
                         )
                         parsed_params.update(path_params)
 
-                # 3. Parse headers
-                if "headers" in kwargs:
-                    headers_dict = kwargs.get("headers", {})
-                    if headers_dict:
-                        header_params = HeaderParser.parse_headers(headers_dict, sig)
-                        parsed_params.update(header_params)
+                # 3. Parse headers for explicit Header() params and implicit
+                # underscore-to-dash name matches. Do not override query/path.
+                headers_dict = kwargs.get("headers", {})
+                if headers_dict:
+                    header_params = HeaderParser.parse_headers(headers_dict, sig)
+                    for _hk, _hv in header_params.items():
+                        if _hk not in parsed_params:
+                            parsed_params[_hk] = _hv
 
                 # 4. Parse request body (JSON)
                 if "body" in kwargs:
@@ -778,12 +775,14 @@ def create_enhanced_handler(original_handler, route_definition):
                                         pass
                             parsed_params.update(params)
 
-                # 3. Parse headers (only if handler needs them)
-                if _has_header_params:
-                    headers_dict = kwargs.get("headers", {})
-                    if headers_dict:
-                        header_params = HeaderParser.parse_headers(headers_dict, sig)
-                        parsed_params.update(header_params)
+                # 3. Parse headers for explicit Header() params and implicit
+                # underscore-to-dash name matches. Do not override query/path.
+                headers_dict = kwargs.get("headers", {})
+                if headers_dict:
+                    header_params = HeaderParser.parse_headers(headers_dict, sig)
+                    for _hk, _hv in header_params.items():
+                        if _hk not in parsed_params:
+                            parsed_params[_hk] = _hv
 
                 # 4. Parse request body (JSON)
                 body_data = kwargs.get("body", b"")

--- a/python/turboapi/security.py
+++ b/python/turboapi/security.py
@@ -506,30 +506,46 @@ from .exceptions import HTTPException  # noqa: F401, E402
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """
-    Verify a password against a hash.
+    Verify a password against a hash produced by get_password_hash().
 
-    This is a placeholder — install a proper hashing library and replace:
-      - passlib with bcrypt: ``passlib.hash.bcrypt.verify(plain, hashed)``
-      - argon2-cffi: ``argon2.PasswordHasher().verify(hashed, plain)``
+    Uses PBKDF2-HMAC-SHA256 with the salt embedded in the stored hash.
+    Format: ``pbkdf2_sha256$<iterations>$<salt_hex>$<hash_hex>``
     """
-    raise NotImplementedError(
-        "verify_password is not implemented. "
-        "Install passlib[bcrypt] or argon2-cffi and replace this function."
-    )
+    import hashlib
+    import hmac as _hmac
+
+    try:
+        tag, iterations_str, salt_hex, stored_hex = hashed_password.split("$")
+    except ValueError:
+        return False
+    if tag != "pbkdf2_sha256":
+        return False
+    try:
+        iterations = int(iterations_str)
+        salt = bytes.fromhex(salt_hex)
+        stored = bytes.fromhex(stored_hex)
+    except (ValueError, TypeError):
+        return False
+    dk = hashlib.pbkdf2_hmac("sha256", plain_password.encode("utf-8"), salt, iterations)
+    return _hmac.compare_digest(dk, stored)
 
 
 def get_password_hash(password: str) -> str:
     """
-    Hash a password.
+    Hash a password using PBKDF2-HMAC-SHA256 with a random 16-byte salt.
 
-    This is a placeholder — install a proper hashing library and replace:
-      - passlib with bcrypt: ``passlib.hash.bcrypt.hash(password)``
-      - argon2-cffi: ``argon2.PasswordHasher().hash(password)``
+    Returns a string in the format:
+    ``pbkdf2_sha256$<iterations>$<salt_hex>$<hash_hex>``
+
+    Pure-stdlib implementation — no extra dependencies required.
     """
-    raise NotImplementedError(
-        "get_password_hash is not implemented. "
-        "Install passlib[bcrypt] or argon2-cffi and replace this function."
-    )
+    import hashlib
+    import os
+
+    iterations = 260_000
+    salt = os.urandom(16)
+    dk = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, iterations)
+    return f"pbkdf2_sha256${iterations}${salt.hex()}${dk.hex()}"
 
 
 # ============================================================================

--- a/python/turboapi/zig_integration.py
+++ b/python/turboapi/zig_integration.py
@@ -602,10 +602,20 @@ class ZigIntegratedTurboAPI(TurboAPI):
         middleware_instances = self._middleware_instances
 
         def middleware_wrapped_handler(**kwargs):
+            def _sanitize_header_component(value: str) -> str:
+                # Prevent CRLF injection when extra headers are tunneled through
+                # the content_type field for the Zig response writer.
+                return value.replace("\r", "").replace("\n", "")
+
+            # Normalize header names to lowercase so middleware can use case-insensitive
+            # dict.get("accept-encoding") lookups regardless of what the Zig HTTP parser
+            # preserved (it keeps the original mixed-case from the wire).
+            raw_headers = kwargs.get("headers", {})
+            normalized_headers = {k.lower(): v for k, v in raw_headers.items()}
             request = Request(
                 method=kwargs.get("method", ""),
                 path=kwargs.get("path", ""),
-                headers=kwargs.get("headers", {}),
+                headers=normalized_headers,
                 body=kwargs.get("body", b""),
                 query_string=kwargs.get("query_string", ""),
                 path_params=kwargs.get("path_params", {}),
@@ -649,10 +659,33 @@ class ZigIntegratedTurboAPI(TurboAPI):
             for mw in reversed(middleware_instances):
                 response = mw.after_request(request, response)
 
-            # Merge middleware-added headers back
+            # Merge middleware-added headers and body back into the result dict.
+            # Extra headers (e.g. Content-Encoding: gzip) are injected into the
+            # content_type string via \r\n so that sendResponse() in Zig emits them
+            # verbatim — no Zig-side header ABI changes required.
             result["status_code"] = response.status_code
             if response.headers:
                 result["extra_headers"] = response.headers
+                base_ct = result.get("content_type") or "application/json"
+                extra_parts = []
+                for hname, hvalue in response.headers.items():
+                    safe_name = _sanitize_header_component(hname)
+                    safe_value = _sanitize_header_component(str(hvalue))
+                    hn_lower = safe_name.lower()
+                    if hn_lower == "content-type":
+                        base_ct = safe_value
+                    elif hn_lower == "content-length":
+                        pass
+                    else:
+                        extra_parts.append(f"{safe_name}: {safe_value}")
+                if extra_parts:
+                    result["content_type"] = base_ct + "\r\n" + "\r\n".join(extra_parts)
+                else:
+                    result["content_type"] = base_ct
+
+            response_body = response.body
+            if response_body:
+                result["content"] = response_body
 
             return result
 

--- a/tests/test_verified_audit_items.py
+++ b/tests/test_verified_audit_items.py
@@ -1,0 +1,103 @@
+"""
+Exact repro tests for issues #96, #97, and #98.
+
+Each test is self-contained, starts its own server on a random port,
+and is the sole acceptance criterion for the corresponding issue.
+"""
+
+import socket
+import threading
+import time
+
+import requests
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _start(app, port, timeout: float = 2.5):
+    t = threading.Thread(target=lambda: app.run(host="127.0.0.1", port=port), daemon=True)
+    t.start()
+    time.sleep(timeout)
+
+
+def test_verified_gzip_passthrough_round_trip():
+    """Issue #96 repro."""
+    import os
+
+    os.environ["TURBO_DISABLE_CACHE"] = "1"
+
+    from turboapi import TurboAPI
+    from turboapi.middleware import GZipMiddleware
+
+    app = TurboAPI(title="GZip test")
+    app.add_middleware(GZipMiddleware, minimum_size=10)
+
+    @app.get("/large")
+    def large_response():
+        return {"data": "A" * 1000}
+
+    port = _free_port()
+    _start(app, port)
+
+    r = requests.get(
+        f"http://127.0.0.1:{port}/large",
+        headers={"Accept-Encoding": "gzip"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.headers.get("Content-Encoding") == "gzip", (
+        f"Expected Content-Encoding: gzip, got headers: {dict(r.headers)}"
+    )
+    data = r.json()
+    assert len(data["data"]) == 1000
+
+
+def test_verified_implicit_header_extraction():
+    """Issue #97 repro."""
+    import os
+
+    os.environ["TURBO_DISABLE_CACHE"] = "1"
+
+    from turboapi import TurboAPI
+    from turboapi.middleware import LoggingMiddleware
+
+    app = TurboAPI(title="Header test")
+    app.add_middleware(LoggingMiddleware)
+
+    @app.get("/implicit-headers")
+    def implicit_headers(authorization: str = "missing", x_request_id: str = "missing"):
+        return {"authorization": authorization, "request_id": x_request_id}
+
+    port = _free_port()
+    _start(app, port)
+
+    r = requests.get(
+        f"http://127.0.0.1:{port}/implicit-headers",
+        headers={"Authorization": "Bearer token123", "X-Request-ID": "req-42"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body == {"authorization": "Bearer token123", "request_id": "req-42"}, (
+        f"Implicit header extraction failed: {body}"
+    )
+
+
+def test_verified_password_hashing_helpers():
+    """Issue #98 repro."""
+    from turboapi.security import get_password_hash, verify_password
+
+    password = "correct-horse-battery-staple"
+    hashed = get_password_hash(password)
+
+    assert isinstance(hashed, str) and hashed
+    assert hashed != password
+    assert verify_password(password, hashed) is True
+    assert verify_password("wrong-password", hashed) is False
+
+    hashed2 = get_password_hash(password)
+    assert hashed != hashed2
+    assert verify_password(password, hashed2) is True
+    assert verify_password("bad", hashed2) is False

--- a/zig/src/server.zig
+++ b/zig/src/server.zig
@@ -1848,13 +1848,20 @@ fn callPythonHandler(tstate: ?*anyopaque, entry: HandlerEntry, method: []const u
         }
     }
 
-    // content — json.dumps() if not already a string
+    // content — json.dumps() if not already a string or raw bytes
     var body_slice: []const u8 = "null";
     if (c.PyDict_GetItemString(result, "content")) |content_obj| {
         if (c.PyUnicode_Check(content_obj) != 0) {
             // Already a string, use directly
             if (c.PyUnicode_AsUTF8(content_obj)) |cs| {
                 body_slice = std.mem.span(cs);
+            }
+        } else if (c.PyBytes_Check(content_obj) != 0) {
+            // Raw bytes — used by GZipMiddleware and other body-mutating middleware.
+            var size: c.Py_ssize_t = 0;
+            var buf: [*c]u8 = undefined;
+            if (c.PyBytes_AsStringAndSize(content_obj, @ptrCast(&buf), &size) == 0) {
+                body_slice = buf[0..@intCast(size)];
             }
         } else {
             // Serialize via json.dumps()


### PR DESCRIPTION
## Summary
- fixes #96, #97, and #98 on current `main`
- restores gzip header/body passthrough on the Zig runtime
- restores implicit header-name extraction for plain handler parameters
- replaces placeholder password hashing helpers with working stdlib PBKDF2 helpers
- adds exact repro coverage in `tests/test_verified_audit_items.py`

## Files Touched
- `python/turboapi/request_handler.py`
- `python/turboapi/security.py`
- `python/turboapi/zig_integration.py`
- `zig/src/server.zig`
- `tests/test_verified_audit_items.py`

## Before
Exact repro on `origin/main` using the added repro file:

```bash
uv run --python 3.14t --extra dev --with requests python -m pytest tests/test_verified_audit_items.py -p no:anchorpy -q
```

Result on `origin/main`:
- `test_verified_gzip_passthrough_round_trip` failed: missing `Content-Encoding: gzip`
- `test_verified_implicit_header_extraction` failed: plain params stayed `missing`
- `test_verified_password_hashing_helpers` failed: `NotImplementedError`

## After
Same repro on this branch:

```bash
uv run --python 3.14t --extra dev --with requests python -m pytest tests/test_verified_audit_items.py -p no:anchorpy -q
```

Result:
- `3 passed in 5.20s`

## Nearby Non-Regression Checks
```bash
uv run --python 3.14t --extra dev --with requests python -m pytest tests/test_middleware_compat.py tests/test_query_and_headers.py tests/test_security_audit_fixes.py -p no:anchorpy -q -k "cors_noargs_get or no_middleware_body_unchanged or query_parameters_comprehensive or rate_limiter_has_lock or cors_wildcard_credentials_raises"
```

Result:
- `5 passed, 23 deselected in 5.08s`

## Scope / Rebase / Churn
- branch was created from current `main`
- no generated artifacts committed
- no lockfile churn committed
- no benchmark changes
