### PR TITLE
fix: resolve yxlyx issues #97, #98; prep #96

### DIFF
--- a/python/turboapi/middleware.py
+++ b/python/turboapi/middleware.py
@@ -183,7 +183,9 @@ class GZipMiddleware(Middleware):
 
     def after_request(self, request: Request, response: Response) -> Response:
         """Compress response if client accepts gzip."""
-        accept_encoding = request.headers.get("accept-encoding", "")
+        # Use get_header() for case-insensitive lookup — Zig passes headers
+        # with their original HTTP capitalisation (e.g. "Accept-Encoding").
+        accept_encoding = request.get_header("accept-encoding", "")
 
         if "gzip" not in accept_encoding.lower():
             return response

--- a/python/turboapi/request_handler.py
+++ b/python/turboapi/request_handler.py
@@ -647,11 +647,19 @@ def create_enhanced_handler(original_handler, route_definition):
     for pname, param in sig.parameters.items():
         if isinstance(param.default, Header):
             _has_header_params = True
+        elif not (
+            _has_security
+            and (
+                isinstance(param.default, (Depends, SecurityBase))
+                or get_depends(param) is not None
+            )
+        ):
+            # Plain param (no explicit non-header marker) — may be an implicit header
+            _has_header_params = True
         if _has_security and (
             isinstance(param.default, (Depends, SecurityBase)) or get_depends(param) is not None
         ):
             _has_dependencies = True
-
     if is_async:
         # Create async enhanced handler for async original handlers
         async def enhanced_handler(**kwargs):

--- a/python/turboapi/security.py
+++ b/python/turboapi/security.py
@@ -505,33 +505,28 @@ from .exceptions import HTTPException  # noqa: F401, E402
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    """
-    Verify a password against a hash.
-
-    This is a placeholder — install a proper hashing library and replace:
-      - passlib with bcrypt: ``passlib.hash.bcrypt.verify(plain, hashed)``
-      - argon2-cffi: ``argon2.PasswordHasher().verify(hashed, plain)``
-    """
-    raise NotImplementedError(
-        "verify_password is not implemented. "
-        "Install passlib[bcrypt] or argon2-cffi and replace this function."
-    )
-
-
+    """Verify a password against a PBKDF2-HMAC-SHA256 hash."""
+    import hashlib
+    import secrets
+    try:
+        algorithm, iterations_str, salt_b64, hash_b64 = hashed_password.split("$")
+        if algorithm != "pbkdf2-sha256":
+            return False
+        iterations = int(iterations_str)
+        salt = bytes.fromhex(salt_b64)
+        expected = bytes.fromhex(hash_b64)
+        digest = hashlib.pbkdf2_hmac("sha256", plain_password.encode(), salt, iterations)
+        return secrets.compare_digest(digest, expected)
+    except Exception:
+        return False
 def get_password_hash(password: str) -> str:
-    """
-    Hash a password.
-
-    This is a placeholder — install a proper hashing library and replace:
-      - passlib with bcrypt: ``passlib.hash.bcrypt.hash(password)``
-      - argon2-cffi: ``argon2.PasswordHasher().hash(password)``
-    """
-    raise NotImplementedError(
-        "get_password_hash is not implemented. "
-        "Install passlib[bcrypt] or argon2-cffi and replace this function."
-    )
-
-
+    """Hash a password using PBKDF2-HMAC-SHA256."""
+    import hashlib
+    import os
+    iterations = 260_000
+    salt = os.urandom(16)
+    digest = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, iterations)
+    return f"pbkdf2-sha256${iterations}${salt.hex()}${digest.hex()}"
 # ============================================================================
 # Dependency Injection Helper
 # ============================================================================

--- a/python/turboapi/zig_integration.py
+++ b/python/turboapi/zig_integration.py
@@ -57,6 +57,7 @@ def classify_handler(handler, route) -> tuple[str, dict[str, str], dict]:
     if has_depends:
         return "enhanced", {}, {}
 
+    has_implicit_header_params = False
     for param_name, param in sig.parameters.items():
         annotation = param.annotation
 
@@ -92,6 +93,11 @@ def classify_handler(handler, route) -> tuple[str, dict[str, str], dict]:
             param_types[param_name] = "bool"
         elif annotation is str or annotation is inspect.Parameter.empty:
             param_types[param_name] = "str"
+            # Optional str params (with defaults) may be implicit header params.
+            # The Zig vectorcall path only extracts path/query params, so route
+            # these handlers through the enhanced path which also checks headers.
+            if param.default is not inspect.Parameter.empty:
+                has_implicit_header_params = True
 
     method = route.method.value.upper() if hasattr(route, "method") else "GET"
 
@@ -115,11 +121,15 @@ def classify_handler(handler, route) -> tuple[str, dict[str, str], dict]:
             return "enhanced", param_types, {}
         return "body_sync", param_types, {}
 
+    # GET handlers with optional str params may use implicit header mapping —
+    # the Zig vectorcall path doesn't inspect headers, so use the enhanced path.
+    if has_implicit_header_params:
+        return "enhanced", param_types, {}
+
     # Zero-arg GET: use the PyObject_CallNoArgs fast path in Zig
     if not param_types:
         return "simple_sync_noargs", param_types, {}
     return "simple_sync", param_types, {}
-
 
 def _extract_model_schema(model_class) -> str | None:
     """Extract a JSON schema descriptor from a dhi BaseModel class for Zig-native validation.
@@ -641,18 +651,37 @@ class ZigIntegratedTurboAPI(TurboAPI):
                 }
 
             # Run after_request
+            # JSON-serialize dict/list content so Response._render() gets a
+            # string it can .encode() — raw dicts crash on .encode().
+            raw_content = result.get("content", "")
+            if isinstance(raw_content, (dict, list)):
+                import json as _json
+                raw_content = _json.dumps(raw_content)
             response = Response(
-                content=result.get("content", ""),
+                content=raw_content,
                 status_code=result.get("status_code", 200),
                 headers={},
             )
             for mw in reversed(middleware_instances):
                 response = mw.after_request(request, response)
 
-            # Merge middleware-added headers back
+            # Merge middleware-modified content and headers back into result
             result["status_code"] = response.status_code
+            # Propagate any body mutation (e.g. GZipMiddleware replaces content
+            # with compressed bytes).
+            result["content"] = response.content
             if response.headers:
-                result["extra_headers"] = response.headers
+                # Filter out headers that Zig already emits from its fixed set
+                _ZIG_OWNED = frozenset({"content-length", "server", "date", "connection"})
+                extra = {k: v for k, v in response.headers.items()
+                         if k.lower() not in _ZIG_OWNED}
+                if extra:
+                    # Inject extra headers via content_type — Zig emits
+                    # "Content-Type: <ct>" so we append "\r\nKey: Value" pairs.
+                    # This avoids needing a Zig-side sendResponseExt function.
+                    ct = result.get("content_type", "application/json")
+                    suffix = "".join(f"\r\n{k}: {v}" for k, v in extra.items())
+                    result["content_type"] = ct + suffix
 
             return result
 

--- a/tests/test_security_audit_fixes.py
+++ b/tests/test_security_audit_fixes.py
@@ -108,21 +108,19 @@ def test_cors_explicit_origin_with_credentials_ok():
 # ── Bug #11: Password hash placeholder ──────────────────────────────────────
 
 def test_get_password_hash_raises():
-    """Bug #11: get_password_hash must NOT return plaintext."""
+    """Bug #11: get_password_hash now returns a real hash (not plaintext)."""
     from turboapi.security import get_password_hash
 
-    with pytest.raises(NotImplementedError):
-        get_password_hash("secret123")
-
-
+    h = get_password_hash("secret123")
+    assert h != "secret123", "must not return plaintext"
+    assert "pbkdf2" in h, "must use pbkdf2"
 def test_verify_password_raises():
-    """Bug #11: verify_password must NOT do plaintext comparison."""
-    from turboapi.security import verify_password
+    """Bug #11: verify_password now works correctly (returns bool, not raises)."""
+    from turboapi.security import get_password_hash, verify_password
 
-    with pytest.raises(NotImplementedError):
-        verify_password("secret123", "secret123")
-
-
+    h = get_password_hash("secret123")
+    assert verify_password("secret123", h) is True
+    assert verify_password("wrong", h) is False
 # ── Bug #5: Port range validation ───────────────────────────────────────────
 # (Zig-side — tested via integration; can't unit test @intCast directly)
 

--- a/tests/test_verified_audit_items.py
+++ b/tests/test_verified_audit_items.py
@@ -1,0 +1,115 @@
+"""
+Verified audit items — regression tests for issues resolved in the audit.
+"""
+import os
+import random
+import sys
+import threading
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
+
+try:
+    import requests
+except ImportError:
+    requests = None
+
+
+def test_verified_password_hashing_helpers():
+    """Issue #98: get_password_hash and verify_password must be functional."""
+    from turboapi.security import get_password_hash, verify_password
+
+    hashed = get_password_hash("mysecret")
+    assert hashed != "mysecret", "must not return plaintext"
+    assert verify_password("mysecret", hashed) is True
+    assert verify_password("wrongpassword", hashed) is False
+
+
+def _free_port():
+    return random.randint(19600, 19699)
+
+
+def test_verified_implicit_header_extraction():
+    """
+    Issue #97: Implicit header-name mapping must populate plain handler params on Zig runtime.
+
+    FastAPI maps snake_case param names to hyphenated HTTP headers:
+      authorization  -> Authorization
+      x_request_id   -> X-Request-ID
+    """
+    if requests is None:
+        import pytest
+        pytest.skip("requests not installed")
+
+    from turboapi import TurboAPI
+
+    port = _free_port()
+    app = TurboAPI(title="Implicit Header Test")
+
+    @app.get("/headers")
+    def read_headers(
+        authorization: str = "missing",
+        x_request_id: str = "missing",
+    ):
+        return {"authorization": authorization, "request_id": x_request_id}
+
+    def start_server():
+        app.run(host="127.0.0.1", port=port)
+
+    server_thread = threading.Thread(target=start_server, daemon=True)
+    server_thread.start()
+    time.sleep(2)
+
+    r = requests.get(
+        f"http://127.0.0.1:{port}/headers",
+        headers={"Authorization": "Bearer token123", "X-Request-ID": "req-42"},
+    )
+    assert r.status_code == 200, f"Unexpected status: {r.status_code}\n{r.text}"
+    body = r.json()
+    assert body == {"authorization": "Bearer token123", "request_id": "req-42"}, (
+        f"Implicit header mapping failed: {body}"
+    )
+
+
+def test_verified_gzip_passthrough_round_trip():
+    """
+    Issue #96: GZipMiddleware on Zig runtime must set Content-Encoding: gzip
+    and return a correctly compressed body.
+    """
+    if requests is None:
+        import pytest
+        pytest.skip("requests not installed")
+
+    from turboapi import TurboAPI
+    from turboapi.middleware import GZipMiddleware
+
+    port = _free_port()
+    app = TurboAPI(title="GZip Test")
+    app.add_middleware(GZipMiddleware, minimum_size=10)
+
+    payload = {"data": "A" * 1000}
+
+    @app.get("/large")
+    def large_response():
+        return payload
+
+    def start_server():
+        app.run(host="127.0.0.1", port=port)
+
+    server_thread = threading.Thread(target=start_server, daemon=True)
+    server_thread.start()
+    time.sleep(2)
+
+    # requests decompresses gzip automatically; disable to inspect raw header
+    r = requests.get(
+        f"http://127.0.0.1:{port}/large",
+        headers={"Accept-Encoding": "gzip"},
+        stream=True,
+    )
+    assert r.status_code == 200, f"Unexpected status: {r.status_code}\n{r.text}"
+    assert r.headers.get("Content-Encoding") == "gzip", (
+        f"Expected Content-Encoding: gzip, got: {r.headers}"
+    )
+    # Decompress and verify round-trip integrity
+    data = r.json()
+    assert data["data"] == "A" * 1000, f"Body was mangled: {data}"


### PR DESCRIPTION
## Summary
- **#98** — Password hashing: replaced `NotImplementedError` stubs with real PBKDF2-HMAC-SHA256 (260k iterations, random 16-byte salt, constant-time comparison)
- **#97** — Implicit header mapping: plain handler params with defaults now route through the enhanced dispatch path which checks request headers, matching FastAPI's implicit `Header()` behavior
- **#96** — GZip middleware (partial): case-insensitive header lookup, JSON-serialize dict content before `Response()`, propagate compressed body + inject extra headers via content_type. Python side fully working; needs Zig rebuild to add `PyBytes_Check` in `callPythonHandler`

## Test plan
- [x] `test_verified_implicit_header_extraction` passes (#97)
- [x] `test_verified_password_hashing_helpers` passes (#98)
- [x] `test_get_password_hash_raises` and `test_verify_password_raises` updated and passing (#98)
- [x] 318 tests pass, 0 regressions
- [ ] `test_verified_gzip_passthrough_round_trip` (#96) — needs `python zig/build_turbonet.py --install` on a machine with sufficient RAM

Closes #97, closes #98
Ref #96