### PR TITLE
fix: restore gzip middleware body passthrough on Zig runtime

### DIFF
--- a/python/turboapi/zig_integration.py
+++ b/python/turboapi/zig_integration.py
@@ -612,10 +612,17 @@ class ZigIntegratedTurboAPI(TurboAPI):
         middleware_instances = self._middleware_instances
 
         def middleware_wrapped_handler(**kwargs):
+            def _sanitize_header_component(value: str) -> str:
+                # Prevent CRLF injection when extra headers are tunneled through
+                # the content_type field for the Zig response writer.
+                return value.replace("\r", "").replace("\n", "")
+
+            raw_headers = kwargs.get("headers", {})
+            normalized_headers = {k.lower(): v for k, v in raw_headers.items()}
             request = Request(
                 method=kwargs.get("method", ""),
                 path=kwargs.get("path", ""),
-                headers=kwargs.get("headers", {}),
+                headers=normalized_headers,
                 body=kwargs.get("body", b""),
                 query_string=kwargs.get("query_string", ""),
                 path_params=kwargs.get("path_params", {}),
@@ -673,15 +680,26 @@ class ZigIntegratedTurboAPI(TurboAPI):
             if response.headers:
                 # Filter out headers that Zig already emits from its fixed set
                 _ZIG_OWNED = frozenset({"content-length", "server", "date", "connection"})
-                extra = {k: v for k, v in response.headers.items()
-                         if k.lower() not in _ZIG_OWNED}
+                extra = {
+                    k: v for k, v in response.headers.items() if k.lower() not in _ZIG_OWNED
+                }
                 if extra:
                     # Inject extra headers via content_type — Zig emits
                     # "Content-Type: <ct>" so we append "\r\nKey: Value" pairs.
                     # This avoids needing a Zig-side sendResponseExt function.
                     ct = result.get("content_type", "application/json")
-                    suffix = "".join(f"\r\n{k}: {v}" for k, v in extra.items())
-                    result["content_type"] = ct + suffix
+                    extra_lines = []
+                    for key, value in extra.items():
+                        safe_key = _sanitize_header_component(str(key))
+                        safe_value = _sanitize_header_component(str(value))
+                        if safe_key.lower() == "content-type":
+                            ct = safe_value
+                            continue
+                        extra_lines.append(f"{safe_key}: {safe_value}")
+                    if extra_lines:
+                        result["content_type"] = ct + "\r\n" + "\r\n".join(extra_lines)
+                    else:
+                        result["content_type"] = ct
 
             return result
 

--- a/zig/src/server.zig
+++ b/zig/src/server.zig
@@ -1849,13 +1849,19 @@ fn callPythonHandler(tstate: ?*anyopaque, entry: HandlerEntry, method: []const u
         }
     }
 
-    // content — json.dumps() if not already a string
+    // content — json.dumps() if not already a string or raw bytes
     var body_slice: []const u8 = "null";
     if (c.PyDict_GetItemString(result, "content")) |content_obj| {
         if (c.PyUnicode_Check(content_obj) != 0) {
             // Already a string, use directly
             if (c.PyUnicode_AsUTF8(content_obj)) |cs| {
                 body_slice = std.mem.span(cs);
+            }
+        } else if (c.PyBytes_Check(content_obj) != 0) {
+            var size: c.Py_ssize_t = 0;
+            var buf: [*c]u8 = undefined;
+            if (c.PyBytes_AsStringAndSize(content_obj, @ptrCast(&buf), &size) == 0) {
+                body_slice = buf[0..@intCast(size)];
             }
         } else {
             // Serialize via json.dumps()


### PR DESCRIPTION
## Summary
- fixes #96 on current `main`
- normalize request headers to lowercase before Python middleware sees them
- sanitize tunneled header lines before appending them to the Zig response path
- preserve raw `bytes` bodies in the Zig response bridge so gzip-compressed middleware output is not JSON-serialized to `null`

## Verification
```bash
python zig/build_turbonet.py --install
uv run --python 3.14t --extra dev --with requests python -m pytest \
  tests/test_verified_audit_items.py::test_verified_gzip_passthrough_round_trip \
  tests/test_middleware_compat.py::test_gzip_middleware_compat \
  tests/test_middleware_compat.py::test_gzip_body_is_actually_compressed \
  -p no:anchorpy -q
```

Result: `1 passed, 2 xpassed`

## Scope
- no redis-related changes
- no version/release metadata changes
- narrow follow-up to the partially merged `#110` work