### PR TITLE
release: bump TurboAPI to v1.0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to TurboAPI are documented here.
 
+## [1.0.24] — 2026-03-31
+
+### Bug Fixes
+
+- Restored Zig-runtime gzip middleware body passthrough so compressed responses keep the correct `Content-Encoding: gzip` header and the actual compressed body.
+- Normalized middleware-visible request headers to lowercase before Python-side processing.
+- Preserved raw `bytes` response bodies in the Zig bridge instead of JSON-serializing compressed middleware output to `null`.
+
+### Closed Issues
+
+- [#96](https://github.com/justrach/turboAPI/issues/96) — gzip middleware on Zig runtime dropped or mangled compressed responses
+
 ## [1.0.23] — 2026-03-27
 
 ### Architecture

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ The app also exposes an ASGI `__call__` fallback — you can use `uvicorn main:a
 
 ## What's New
 
+### v1.0.24 — Zig gzip passthrough fix
+
+Restored gzip middleware body passthrough on the Zig runtime so compressed responses keep both the correct `Content-Encoding: gzip` header and the actual compressed body. This closes issue #96 on current `main`.
+
 ### v1.0.23 — Shared Zig core (`turboapi-core`)
 
 Extracted the radix trie router, HTTP utilities, and response cache into a standalone Zig library — [**turboapi-core**](turboapi-core/). Both turboAPI and [merjs](https://github.com/justrach/merjs) now share the same routing and HTTP primitives. Zero performance regression (134k req/s unchanged).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboapi"
-version = "1.0.23"
+version = "1.0.24"
 description = "FastAPI-compatible web framework with Zig HTTP core — 20x faster with Python 3.14 free-threading"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="turboapi",
-    version="1.0.22",
+    version="1.0.24",
     description="A high-performance Python web framework for the no-GIL era",
     long_description=open("../README.md").read(),
     long_description_content_type="text/markdown",

--- a/python/turboapi/__init__.py
+++ b/python/turboapi/__init__.py
@@ -92,7 +92,7 @@ from .version_check import check_free_threading_support, get_python_threading_in
 # WebSocket
 from .websockets import WebSocket, WebSocketDisconnect
 
-__version__ = "1.0.22"
+__version__ = "1.0.24"
 __all__ = [
     # Core
     "TurboAPI",


### PR DESCRIPTION
## Summary
- bump TurboAPI version metadata to `1.0.24`
- sync `pyproject.toml`, `python/setup.py`, and `python/turboapi/__init__.py`
- add README and changelog entries for the Zig gzip passthrough fix merged in `#111`

## Notes
- this is a release metadata/docs sync only
- no redis-related changes
- closes the metadata drift where `pyproject.toml` was ahead of the Python package version surfaces