### PR TITLE
Fix release metadata for v1.0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to TurboAPI are documented here.
 
+## [1.0.26] — 2026-04-01
+
+### Release Fixes
+
+- Re-cut the patch release after `v1.0.25` published assets with stale `1.0.24` version metadata.
+- Synced version declarations across `pyproject.toml`, `python/setup.py`, and `python/turboapi/__init__.py`.
+- Added a regression test that fails if release metadata files drift out of sync again.
+
 ## [1.0.25] — 2026-04-01
 
 ### Compatibility

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ The app also exposes an ASGI `__call__` fallback — you can use `uvicorn main:a
 
 ## What's New
 
+### v1.0.26 — release metadata fix
+
+Re-cut the patch release after `v1.0.25` published stale `1.0.24` artifacts. `v1.0.26` syncs the package version across all release metadata files and adds a regression test so future release bumps fail fast if those files drift.
+
 ### v1.0.25 — yxlyx compatibility cleanup
 
 Fixed the top-level password helper exports so `turboapi.hash_password` and `turboapi.verify_password` stay coherent, and removed stale async-handler `xfail` markers for cases that already pass on current `main`. This closes issues #116 and #117.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboapi"
-version = "1.0.25"
+version = "1.0.26"
 description = "FastAPI-compatible web framework with Zig HTTP core — 20x faster with Python 3.14 free-threading"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="turboapi",
-    version="1.0.25",
+    version="1.0.26",
     description="A high-performance Python web framework for the no-GIL era",
     long_description=open("../README.md").read(),
     long_description_content_type="text/markdown",

--- a/python/turboapi/__init__.py
+++ b/python/turboapi/__init__.py
@@ -94,7 +94,7 @@ from .version_check import check_free_threading_support, get_python_threading_in
 # WebSocket
 from .websockets import WebSocket, WebSocketDisconnect
 
-__version__ = "1.0.25"
+__version__ = "1.0.26"
 __all__ = [
     # Core
     "TurboAPI",

--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -1,0 +1,35 @@
+"""Release metadata regression tests."""
+
+import re
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+SETUP = ROOT / "python" / "setup.py"
+PACKAGE_INIT = ROOT / "python" / "turboapi" / "__init__.py"
+
+
+def _read_pyproject_version() -> str:
+    data = tomllib.loads(PYPROJECT.read_text())
+    return data["project"]["version"]
+
+
+def _extract_string_assignment(path: Path, pattern: str) -> str:
+    match = re.search(pattern, path.read_text())
+    assert match, f"Could not find version pattern in {path}"
+    return match.group(1)
+
+
+def test_release_versions_are_in_sync():
+    """Release metadata files must all declare the same package version."""
+    pyproject_version = _read_pyproject_version()
+    setup_version = _extract_string_assignment(SETUP, r'version="([^"]+)"')
+    package_version = _extract_string_assignment(PACKAGE_INIT, r'__version__ = "([^"]+)"')
+
+    assert pyproject_version == setup_version == package_version
+
+
+def test_release_version_bumped_past_bad_1_0_25_publish():
+    """This release must move past the broken 1.0.25 artifact metadata."""
+    assert _read_pyproject_version() == "1.0.26"


### PR DESCRIPTION
## Summary
- bump TurboAPI release metadata from `1.0.25` to `1.0.26`
- sync the version across `pyproject.toml`, `python/setup.py`, and `python/turboapi/__init__.py`
- add release notes explaining that `v1.0.26` supersedes the bad `v1.0.25` publish
- add a regression test that fails if release metadata files drift out of sync again

## Why
`v1.0.25` published assets labeled `1.0.24`, so this re-cuts the patch release on a fresh PR instead of tagging directly from a dirty/stale state.

## Tests
- `PYTHONPATH=/tmp/turboapi-release-126-pr/python /Users/rachpradhan/turboAPI/.venv/bin/python -m pytest tests/test_release_version_sync.py -q`
- pre-commit hook suite during commit (`ruff`, TurboPG tests, Annotated Depends tests, security tests)
