### PR TITLE
Fix release process and bump to v1.0.27

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -21,6 +21,17 @@ jobs:
         id: version
         run: |
           VERSION=$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/')
+          SETUP_VERSION=$(grep -m1 'version="' python/setup.py | sed 's/.*version="\([^"]*\)".*/\1/')
+          INIT_VERSION=$(grep -m1 '__version__ = ' python/turboapi/__init__.py | sed 's/.*"\(.*\)"/\1/')
+
+          test "$VERSION" = "$SETUP_VERSION"
+          test "$VERSION" = "$INIT_VERSION"
+
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            TAG_VERSION="${GITHUB_REF_NAME#v}"
+            test "$VERSION" = "$TAG_VERSION"
+          fi
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,14 @@ jobs:
           [bumpversion:file:pyproject.toml]
           search = version = "{current_version}"
           replace = version = "{new_version}"
+
+          [bumpversion:file:python/setup.py]
+          search = version="{current_version}"
+          replace = version="{new_version}"
+
+          [bumpversion:file:python/turboapi/__init__.py]
+          search = __version__ = "{current_version}"
+          replace = __version__ = "{new_version}"
           EOF
 
           bump2version ${{ github.event.inputs.version_bump }} --allow-dirty
@@ -59,7 +67,7 @@ jobs:
           VERSION="${{ steps.bump.outputs.version }}"
           git config user.email "action@github.com"
           git config user.name "GitHub Action"
-          git add pyproject.toml .bumpversion.cfg
+          git add pyproject.toml python/setup.py python/turboapi/__init__.py .bumpversion.cfg
           git commit -m "release: v${VERSION}"
           git tag "v${VERSION}"
           git push && git push --tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,29 @@ All notable changes to TurboAPI are documented here.
 
 ## [1.0.27] — 2026-04-01
 
-### Release Fixes
+### Since 1.0.24
+
+#### Compatibility
+
+- Fixed package-level password helper exports so the top-level `turboapi` API no longer mixes implementations between `hash_password` and `verify_password`.
+- Added regression coverage that locks the top-level password helpers to the `turboapi.security` implementation.
+
+#### Test Suite
+
+- Removed stale `xfail` markers from the async handler suite for cases that now pass on current `main`.
+- Kept the remaining async error-handling gap explicit with a strict `xfail` instead of silently masking newly passing behavior.
+- Added release metadata regression coverage so version declarations must stay aligned across packaging files.
+
+#### Release Fixes
 
 - Re-cut the patch release after both `v1.0.25` and `v1.0.26` published stale assets from older tag targets.
 - Added workflow checks so tag pushes fail if the tag version and repository version declarations do not match.
-- Fixed the manual release workflow so future bump automation updates all version declarations, not just `pyproject.toml`.
+- Fixed the manual release workflow so future bump automation updates `pyproject.toml`, `python/setup.py`, and `python/turboapi/__init__.py` together.
+
+#### Closed Issues
+
+- [#116](https://github.com/justrach/turboAPI/issues/116) — package-level `turboapi.verify_password` resolved to the wrong helper
+- [#117](https://github.com/justrach/turboAPI/issues/117) — async handler suite contained stale `xfail` markers
 
 ## [1.0.26] — 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to TurboAPI are documented here.
 
+## [1.0.27] — 2026-04-01
+
+### Release Fixes
+
+- Re-cut the patch release after both `v1.0.25` and `v1.0.26` published stale assets from older tag targets.
+- Added workflow checks so tag pushes fail if the tag version and repository version declarations do not match.
+- Fixed the manual release workflow so future bump automation updates all version declarations, not just `pyproject.toml`.
+
 ## [1.0.26] — 2026-04-01
 
 ### Release Fixes

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ The app also exposes an ASGI `__call__` fallback — you can use `uvicorn main:a
 
 ## What's New
 
+### v1.0.27 — release guardrails
+
+Re-cut the patch release after bad `v1.0.25` and `v1.0.26` publishes. `v1.0.27` adds release guardrails so tag pushes fail on version drift and the manual release workflow updates every version declaration consistently.
+
 ### v1.0.26 — release metadata fix
 
 Re-cut the patch release after `v1.0.25` published stale `1.0.24` artifacts. `v1.0.26` syncs the package version across all release metadata files and adds a regression test so future release bumps fail fast if those files drift.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboapi"
-version = "1.0.26"
+version = "1.0.27"
 description = "FastAPI-compatible web framework with Zig HTTP core — 20x faster with Python 3.14 free-threading"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="turboapi",
-    version="1.0.26",
+    version="1.0.27",
     description="A high-performance Python web framework for the no-GIL era",
     long_description=open("../README.md").read(),
     long_description_content_type="text/markdown",

--- a/python/turboapi/__init__.py
+++ b/python/turboapi/__init__.py
@@ -94,7 +94,7 @@ from .version_check import check_free_threading_support, get_python_threading_in
 # WebSocket
 from .websockets import WebSocket, WebSocketDisconnect
 
-__version__ = "1.0.26"
+__version__ = "1.0.27"
 __all__ = [
     # Core
     "TurboAPI",

--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -31,5 +31,5 @@ def test_release_versions_are_in_sync():
 
 
 def test_release_version_bumped_past_bad_1_0_25_publish():
-    """This release must move past the broken 1.0.25 artifact metadata."""
-    assert _read_pyproject_version() == "1.0.26"
+    """This release must move past the broken 1.0.25/1.0.26 artifact publishes."""
+    assert _read_pyproject_version() == "1.0.27"


### PR DESCRIPTION
## Summary
- bump TurboAPI from `1.0.26` to `1.0.27`
- add a `Build & Publish` guard that fails if the git tag version does not match the repo's declared package version
- fix the manual `release.yml` workflow so it updates `pyproject.toml`, `python/setup.py`, and `python/turboapi/__init__.py` together
- keep the release-version regression test aligned with `1.0.27`

## Root Cause
The bad `v1.0.25` and `v1.0.26` publishes were caused by creating tags against older commits than intended. The publish workflow then correctly built the stale code those tags pointed to.

This PR fixes that properly by:
- making tag/repo version mismatches fail immediately in CI
- making the manual release workflow update all version declarations consistently
- re-cutting the release as `v1.0.27`

## Cleanup
- deleted the bad remote tags `v1.0.25` and `v1.0.26`
- removed the corresponding GitHub release objects

## Tests
- `PYTHONPATH=/tmp/turboapi-release-127-pr/python /Users/rachpradhan/turboAPI/.venv/bin/python -m pytest tests/test_release_version_sync.py -q`
- pre-commit hook suite during commit (`ruff`, TurboPG tests, Annotated Depends tests, security tests)
