### PR TITLE
feat: improve perf regression CI — faster PRs, trends, metadata, weekly FastAPI

### DIFF
--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run regression benchmark (main - full)
         if: github.ref == 'refs/heads/main'
-        run: uv run --python 3.14t python benchmarks/bench_regression.py --ci --save --history
+        run: uv run --python 3.14t python benchmarks/bench_regression.py --save --history
         env:
           BENCH_THREADS: 4
           BENCH_CONNECTIONS: 100

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * 1'
 
 permissions:
   issues: write
@@ -41,12 +43,27 @@ jobs:
       - name: Install wrk
         run: sudo apt-get update && sudo apt-get install -y wrk
 
-      - name: Run regression benchmark
+      - name: Run regression benchmark (PR - quick)
+        if: github.event_name == 'pull_request'
         run: uv run --python 3.14t python benchmarks/bench_regression.py --ci
         env:
           BENCH_THREADS: 4
           BENCH_CONNECTIONS: 100
+          BENCH_DURATION: 5
+          BENCH_RUNNER: "ci-pr"
+          BENCH_VCPUS: "2"
+          BENCH_OS: "ubuntu-latest"
+
+      - name: Run regression benchmark (main - full)
+        if: github.ref == 'refs/heads/main'
+        run: uv run --python 3.14t python benchmarks/bench_regression.py --ci --save --history
+        env:
+          BENCH_THREADS: 4
+          BENCH_CONNECTIONS: 100
           BENCH_DURATION: 10
+          BENCH_RUNNER: "ci-main"
+          BENCH_VCPUS: "2"
+          BENCH_OS: "ubuntu-latest"
 
       - name: Post PR comment with results
         if: github.event_name == 'pull_request'
@@ -67,10 +84,9 @@ jobs:
               body: comment,
             });
 
-      - name: Update baseline on main
+      - name: Commit baseline + history on main
         if: github.ref == 'refs/heads/main'
         run: |
-          uv run --python 3.14t python benchmarks/bench_regression.py --save --history
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add benchmarks/baseline.json benchmarks/history/
@@ -85,3 +101,39 @@ jobs:
           path: |
             /tmp/bench_results.json
             /tmp/bench_pr_comment.md
+
+  fastapi-comparison:
+    name: "TurboAPI vs FastAPI weekly"
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.14t (free-threaded)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14t'
+          allow-prereleases: true
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Build turbonet extension
+        run: python zig/build_turbonet.py --install --release
+
+      - name: Install deps
+        run: |
+          pip install -e .
+          pip install uv fastapi pydantic
+
+      - name: Run FastAPI comparison
+        run: uv run --python 3.14t python benchmarks/bench_throughput.py
+
+      - name: Upload comparison results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fastapi-comparison-results
+          path: /tmp/bench_results.json

--- a/benchmarks/bench_regression.py
+++ b/benchmarks/bench_regression.py
@@ -17,7 +17,7 @@ import os
 import subprocess
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 BENCH_DIR = os.path.dirname(os.path.abspath(__file__))
 BASELINE_FILE = os.path.join(BENCH_DIR, "baseline.json")
@@ -157,7 +157,7 @@ def load_thresholds(ci_mode=False):
 
 def save_history(results, detailed=None):
     os.makedirs(HISTORY_DIR, exist_ok=True)
-    ts = datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H-%M-%S")
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")  # noqa: UP017
     history_file = os.path.join(HISTORY_DIR, f"{ts}.json")
     payload = {
         "timestamp": ts,

--- a/benchmarks/bench_regression.py
+++ b/benchmarks/bench_regression.py
@@ -155,14 +155,21 @@ def load_thresholds(ci_mode=False):
     )
 
 
-def save_history(results):
+def save_history(results, detailed=None):
     os.makedirs(HISTORY_DIR, exist_ok=True)
     ts = datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H-%M-%S")
     history_file = os.path.join(HISTORY_DIR, f"{ts}.json")
     payload = {
         "timestamp": ts,
         "results": results,
+        "detailed": detailed or {},
         "commit": os.popen("git rev-parse HEAD 2>/dev/null").read().strip() or "unknown",
+        "runner": os.environ.get("BENCH_RUNNER", "local"),
+        "os": os.environ.get("BENCH_OS", "unknown"),
+        "vcpus": os.environ.get("BENCH_VCPUS", "unknown"),
+        "duration": DURATION,
+        "threads": THREADS,
+        "connections": CONNECTIONS,
     }
     with open(history_file, "w") as f:
         json.dump(payload, f, indent=2)
@@ -170,7 +177,12 @@ def save_history(results):
 
 
 def generate_pr_comment(results, detailed, thresholds, avg_threshold, regressions):
+    runner = os.environ.get("BENCH_RUNNER", "local")
+    duration = DURATION
     lines = ["## Performance Regression Report\n"]
+    lines.append(
+        f"> Runner: **{runner}** | Duration: **{duration}s** per endpoint | Threads: **{THREADS}** | Connections: **{CONNECTIONS}**\n"
+    )
     lines.append("| Endpoint | req/s | avg latency | p99 latency | threshold | status |")
     lines.append("|----------|------:|------------:|------------:|----------:|--------|")
     for name, path, method, body in BENCHMARKS:
@@ -278,7 +290,7 @@ def main():
         json.dump({"results": results, "detailed": detailed}, f, indent=2)
 
     if history_mode or save_mode:
-        save_history(results)
+        save_history(results, detailed)
 
     if ci_mode:
         generate_pr_comment(results, detailed, thresholds, avg_threshold, regressions)

--- a/benchmarks/bench_trends.py
+++ b/benchmarks/bench_trends.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Trend analysis for benchmarks/history/ snapshots.
+
+Usage:
+    python benchmarks/bench_trends.py                    # show last 10 snapshots
+    python benchmarks/bench_trends.py --all              # show all snapshots
+    python benchmarks/bench_trends.py --compare 3         # compare last 3 snapshots
+    python benchmarks/bench_trends.py --endpoint "GET /"  # filter to one endpoint
+"""
+
+import json
+import os
+import sys
+
+HISTORY_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "history")
+
+
+def load_snapshots(limit=None):
+    if not os.path.exists(HISTORY_DIR):
+        print("No history directory found. Run benchmarks with --history first.")
+        return []
+
+    files = sorted(f for f in os.listdir(HISTORY_DIR) if f.endswith(".json"))
+    if limit:
+        files = files[-limit:]
+
+    snapshots = []
+    for fname in files:
+        with open(os.path.join(HISTORY_DIR, fname)) as f:
+            data = json.load(f)
+        snapshots.append(data)
+    return snapshots
+
+
+def print_table(snapshots, endpoint_filter=None):
+    if not snapshots:
+        print("No snapshots found.")
+        return
+
+    endpoints = set()
+    for s in snapshots:
+        endpoints.update(s.get("results", {}).keys())
+    endpoints = sorted(endpoints)
+
+    if endpoint_filter:
+        endpoints = [e for e in endpoints if endpoint_filter.lower() in e.lower()]
+
+    print(f"{'Timestamp':<22} {'Runner':<10} {'vCPUs':<6} ", end="")
+    for ep in endpoints:
+        short = ep.replace("GET ", "G:").replace("POST ", "P:")[:15]
+        print(f"{short:>16}", end="")
+    print(f" {'AVG':>10}")
+    print("-" * (42 + 16 * len(endpoints) + 11))
+
+    for s in snapshots:
+        ts = s.get("timestamp", "unknown")[:19]
+        runner = s.get("runner", "?")
+        vcpus = s.get("vcpus", "?")
+        results = s.get("results", {})
+        print(f"{ts:<22} {runner:<10} {vcpus:<6} ", end="")
+        vals = []
+        for ep in endpoints:
+            v = results.get(ep, 0)
+            vals.append(v)
+            print(f"{v:>15,.0f}", end="")
+        avg = sum(vals) / max(len(vals), 1)
+        print(f" {avg:>10,.0f}")
+
+
+def print_delta(snapshots):
+    if len(snapshots) < 2:
+        print("Need at least 2 snapshots to compute delta.")
+        return
+
+    old = snapshots[-2]
+    new = snapshots[-1]
+    old_r = old.get("results", {})
+    new_r = new.get("results", {})
+
+    endpoints = sorted(set(old_r.keys()) | set(new_r.keys()))
+
+    print(f"\n{'Endpoint':<25} {'Previous':>12} {'Current':>12} {'Delta':>10} {'%':>8}")
+    print("-" * 70)
+    for ep in endpoints:
+        prev = old_r.get(ep, 0)
+        curr = new_r.get(ep, 0)
+        if prev == 0:
+            delta_str = "N/A"
+            pct_str = "N/A"
+        else:
+            delta = curr - prev
+            pct = (delta / prev) * 100
+            delta_str = f"{delta:+,.0f}"
+            pct_str = f"{pct:+.1f}%"
+        print(f"{ep:<25} {prev:>12,.0f} {curr:>12,.0f} {delta_str:>10} {pct_str:>8}")
+
+    prev_avg = sum(old_r.values()) / max(len(old_r), 1)
+    curr_avg = sum(new_r.values()) / max(len(new_r), 1)
+    if prev_avg > 0:
+        delta = curr_avg - prev_avg
+        pct = (delta / prev_avg) * 100
+        print(f"{'AVERAGE':<25} {prev_avg:>12,.0f} {curr_avg:>12,.0f} {delta:+,.0f} {pct:+.1f}%")
+    else:
+        print(f"{'AVERAGE':<25} {prev_avg:>12,.0f} {curr_avg:>12,.0f}")
+
+    print(f"\n  Previous: {old.get('timestamp', '?')[:19]} ({old.get('runner', '?')})")
+    print(f"  Current:  {new.get('timestamp', '?')[:19]} ({new.get('runner', '?')})")
+
+
+def main():
+    limit = 10
+    compare = None
+    endpoint_filter = None
+
+    args = sys.argv[1:]
+    if "--all" in args:
+        limit = None
+    if "--compare" in args:
+        idx = args.index("--compare")
+        if idx + 1 < len(args):
+            compare = int(args[idx + 1])
+        else:
+            compare = 2
+    if "--endpoint" in args:
+        idx = args.index("--endpoint")
+        if idx + 1 < len(args):
+            endpoint_filter = args[idx + 1]
+
+    if compare:
+        snapshots = load_snapshots(limit=compare)
+    else:
+        snapshots = load_snapshots(limit=limit)
+
+    if compare and len(snapshots) >= 2:
+        print_delta(snapshots)
+        print()
+        print_table(snapshots, endpoint_filter)
+    else:
+        print_table(snapshots, endpoint_filter)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Improvements to the performance regression system shipped in #123.

### Changes

- **5s PR benchmarks** — PRs now run 5s per endpoint (30s total) instead of 10s (60s), main pushes still get full 10s runs
- **`bench_trends.py`** — new CLI tool to analyze `benchmarks/history/` snapshots:
  - `python benchmarks/bench_trends.py` — last 10 snapshots table
  - `python benchmarks/bench_trends.py --compare 3` — delta between last 3 runs
  - `python benchmarks/bench_trends.py --endpoint "GET /"` — filter to one endpoint
- **Runner metadata in history** — snapshots now include `runner`, `os`, `vcpus`, `duration`, `threads`, `connections` for apples-to-apples trend comparison
- **Weekly FastAPI comparison** — new `fastapi-comparison` job runs every Monday 02:00 UTC (also triggerable via `workflow_dispatch`)
- **PR comment improvements** — now shows runner type, duration, threads, connections in the comment header

Relates to #122