### PR TITLE
perf: hoist parse_qs / HTTPException imports out of fast handler closures

### DIFF
--- a/benchmarks/bench_handler_dispatch.py
+++ b/benchmarks/bench_handler_dispatch.py
@@ -1,0 +1,134 @@
+"""
+Microbench for `create_fast_handler` per-request closure dispatch.
+
+Measures the Python-side cost of running a single fast-handler call, isolated
+from the Zig HTTP server. Used to prove Python-side hot-path changes have
+measurable impact at the level they actually change (per-request closure body),
+since the end-to-end `bench_regression.py` HTTP throughput has ~15-20%
+run-to-run noise that hides 1-2% Python-side wins.
+
+Run:
+    .venv314t/bin/python benchmarks/bench_handler_dispatch.py
+
+Reports median + p99 over N=200_000 dispatches, four call shapes:
+  * noargs   — 0-param handler
+  * pathonly — 1 path param, no query, no body
+  * pathqs   — 1 path param + query string (exercises parse_qs path)
+  * patherr  — handler raises HTTPException (exercises exception path)
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from typing import Callable
+
+from turboapi.exceptions import HTTPException
+from turboapi.request_handler import create_fast_handler
+from turboapi.routing import HTTPMethod, RouteDefinition
+
+
+# --- handlers -----------------------------------------------------------
+
+def h_noargs():
+    return {"ok": True}
+
+
+def h_pathonly(user_id: int):
+    return {"id": user_id}
+
+
+def h_pathqs(user_id: int, q: str = ""):
+    return {"id": user_id, "q": q}
+
+
+def h_raises(user_id: int):
+    raise HTTPException(status_code=404, detail="not found")
+
+
+# --- helpers ------------------------------------------------------------
+
+def make_route(method: HTTPMethod = HTTPMethod.GET, path: str = "/x") -> RouteDefinition:
+    return RouteDefinition(
+        path=path,
+        method=method,
+        handler=lambda: None,
+        path_params=[],
+        query_params={},
+    )
+
+
+def time_dispatch(fast: Callable, kwargs: dict, n: int) -> tuple[float, float]:
+    # Warmup
+    for _ in range(min(2_000, n // 10)):
+        fast(**kwargs)
+    t0 = time.perf_counter_ns()
+    for _ in range(n):
+        fast(**kwargs)
+    t1 = time.perf_counter_ns()
+    median_ns = (t1 - t0) // n
+    # Per-call samples for p99 from a smaller pass.
+    samples_ns: list[int] = []
+    for _ in range(min(20_000, n // 10)):
+        ts = time.perf_counter_ns()
+        fast(**kwargs)
+        samples_ns.append(time.perf_counter_ns() - ts)
+    p99_ns = sorted(samples_ns)[int(len(samples_ns) * 0.99)]
+    return median_ns, p99_ns
+
+
+# --- benches ------------------------------------------------------------
+
+def bench_noargs(n: int) -> tuple[float, float]:
+    fast = create_fast_handler(h_noargs, make_route())
+    return time_dispatch(fast, {}, n)
+
+
+def bench_pathonly(n: int) -> tuple[float, float]:
+    fast = create_fast_handler(h_pathonly, make_route(path="/users/{user_id}"))
+    return time_dispatch(fast, {"path_params": {"user_id": "42"}}, n)
+
+
+def bench_pathqs(n: int) -> tuple[float, float]:
+    fast = create_fast_handler(h_pathqs, make_route(path="/users/{user_id}"))
+    return time_dispatch(
+        fast,
+        {"path_params": {"user_id": "42"}, "query_string": "q=hello&extra=1"},
+        n,
+    )
+
+
+def bench_patherr(n: int) -> tuple[float, float]:
+    fast = create_fast_handler(h_raises, make_route(path="/users/{user_id}"))
+    return time_dispatch(fast, {"path_params": {"user_id": "42"}}, n)
+
+
+# --- driver -------------------------------------------------------------
+
+def main() -> None:
+    runs = 5
+    n = 200_000
+
+    cases = [
+        ("noargs", bench_noargs),
+        ("pathonly", bench_pathonly),
+        ("pathqs", bench_pathqs),
+        ("patherr", bench_patherr),
+    ]
+
+    print(f"create_fast_handler dispatch microbench  (n={n} per case, {runs} runs)")
+    print(f"{'case':<10} {'median_us':>11} {'p99_us':>10}")
+    for name, fn in cases:
+        med_runs = []
+        p99_runs = []
+        for _ in range(runs):
+            m, p = fn(n)
+            med_runs.append(m)
+            p99_runs.append(p)
+        med_us = statistics.median(med_runs) / 1000
+        p99_us = statistics.median(p99_runs) / 1000
+        print(f"{name:<10} {med_us:>11.3f} {p99_us:>10.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/turboapi/request_handler.py
+++ b/python/turboapi/request_handler.py
@@ -8,6 +8,9 @@ import inspect
 import json
 import typing
 import urllib.parse
+from urllib.parse import parse_qs
+
+from turboapi.exceptions import HTTPException
 from typing import Any, get_origin
 
 from dhi import BaseModel as Model
@@ -95,8 +98,6 @@ class DependencyResolver:
                 result = dep_fn(headers=context.get("headers", {}))
             elif "query_params" in call_params:
                 # APIKeyQuery — parse query string into dict
-                from urllib.parse import parse_qs
-
                 qs = context.get("query_string", "")
                 qp = (
                     {k: v[0] for k, v in parse_qs(qs, keep_blank_values=True).items()} if qs else {}
@@ -1248,13 +1249,8 @@ def create_pos_handler(original_handler):
                 return (result[1], "application/json", _dumps(result[0]))
             return (200, "application/json", _dumps(result))
         except Exception as e:
-            try:
-                from turboapi.exceptions import HTTPException as _HTTPException
-
-                if isinstance(e, _HTTPException):
-                    return (e.status_code, "application/json", _dumps({"detail": e.detail}))
-            except ImportError:
-                pass
+            if isinstance(e, HTTPException):
+                return (e.status_code, "application/json", _dumps({"detail": e.detail}))
             return (500, "application/json", _dumps({"error": str(e)}))
 
     return pos_handler
@@ -1281,13 +1277,8 @@ def create_async_pos_handler(original_handler):
                 return (result[1], "application/json", _dumps(result[0]))
             return (200, "application/json", _dumps(result))
         except Exception as e:
-            try:
-                from turboapi.exceptions import HTTPException as _HTTPException
-
-                if isinstance(e, _HTTPException):
-                    return (e.status_code, "application/json", _dumps({"detail": e.detail}))
-            except ImportError:
-                pass
+            if isinstance(e, HTTPException):
+                return (e.status_code, "application/json", _dumps({"detail": e.detail}))
             return (500, "application/json", _dumps({"error": str(e)}))
 
     return pos_handler
@@ -1342,13 +1333,8 @@ def create_fast_handler(original_handler, route_definition):
                     result = result.model_dump()
                 return (200, "application/json", _dumps(result))
             except Exception as e:
-                try:
-                    from turboapi.exceptions import HTTPException as _HTTPException
-
-                    if isinstance(e, _HTTPException):
-                        return (e.status_code, "application/json", _dumps({"detail": e.detail}))
-                except ImportError:
-                    pass
+                if isinstance(e, HTTPException):
+                    return (e.status_code, "application/json", _dumps({"detail": e.detail}))
                 return (500, "application/json", _dumps({"error": str(e)}))
 
         return fast_handler_noargs
@@ -1367,8 +1353,6 @@ def create_fast_handler(original_handler, route_definition):
             if len(call_kwargs) < len(param_names):
                 qs = kwargs.get("query_string", "")
                 if qs:
-                    from urllib.parse import parse_qs
-
                     for k, v in parse_qs(qs, keep_blank_values=True).items():
                         if k in param_names and k not in call_kwargs:
                             call_kwargs[k] = v[0]
@@ -1408,13 +1392,8 @@ def create_fast_handler(original_handler, route_definition):
         except RequestParsingError as e:
             return (400, "application/json", _dumps({"error": "Bad Request", "detail": str(e)}))
         except Exception as e:
-            try:
-                from turboapi.exceptions import HTTPException
-
-                if isinstance(e, HTTPException):
-                    return (e.status_code, "application/json", _dumps({"detail": e.detail}))
-            except ImportError:
-                pass
+            if isinstance(e, HTTPException):
+                return (e.status_code, "application/json", _dumps({"detail": e.detail}))
             return (500, "application/json", _dumps({"error": str(e)}))
 
     return fast_handler
@@ -1458,8 +1437,6 @@ def create_fast_async_handler(original_handler, route_definition, eager: bool = 
         if len(call_kwargs) < len(param_names):
             qs = kwargs.get("query_string", "")
             if qs:
-                from urllib.parse import parse_qs
-
                 for k, v in parse_qs(qs, keep_blank_values=True).items():
                     if k in param_names and k not in call_kwargs:
                         call_kwargs[k] = v[0]
@@ -1497,13 +1474,8 @@ def create_fast_async_handler(original_handler, route_definition, eager: bool = 
                     _dumps({"error": "Bad Request", "detail": str(e)}),
                 )
             except Exception as e:
-                try:
-                    from turboapi.exceptions import HTTPException
-
-                    if isinstance(e, HTTPException):
-                        return (e.status_code, "application/json", _dumps({"detail": e.detail}))
-                except ImportError:
-                    pass
+                if isinstance(e, HTTPException):
+                    return (e.status_code, "application/json", _dumps({"detail": e.detail}))
                 return (500, "application/json", _dumps({"error": str(e)}))
 
         return fast_handler_eager
@@ -1528,13 +1500,8 @@ def create_fast_async_handler(original_handler, route_definition, eager: bool = 
         except RequestParsingError as e:
             return (400, "application/json", _dumps({"error": "Bad Request", "detail": str(e)}))
         except Exception as e:
-            try:
-                from turboapi.exceptions import HTTPException
-
-                if isinstance(e, HTTPException):
-                    return (e.status_code, "application/json", _dumps({"detail": e.detail}))
-            except ImportError:
-                pass
+            if isinstance(e, HTTPException):
+                return (e.status_code, "application/json", _dumps({"detail": e.detail}))
             return (500, "application/json", _dumps({"error": str(e)}))
 
     return fast_handler
@@ -1569,13 +1536,8 @@ def create_fast_model_handler(original_handler, model_class, param_name):
                 return (result[1], "application/json", _dumps(result[0]))
             return (200, "application/json", _dumps(result))
         except Exception as e:
-            try:
-                from turboapi.exceptions import HTTPException
-
-                if isinstance(e, HTTPException):
-                    return (e.status_code, "application/json", _dumps({"detail": e.detail}))
-            except ImportError:
-                pass
+            if isinstance(e, HTTPException):
+                return (e.status_code, "application/json", _dumps({"detail": e.detail}))
             return (500, "application/json", _dumps({"error": str(e)}))
 
     return fast_model_handler


### PR DESCRIPTION
Closes #147. Sub-task of #42.

## Summary

`python/turboapi/request_handler.py` ran `from urllib.parse import parse_qs` and `from turboapi.exceptions import HTTPException` (with and without an `_HTTPException` alias) inside the per-request closure bodies of the named fast handlers that the Zig backend dispatches into. Each request paid a `sys.modules` dict lookup + frame setup on imports that are constant across the process lifetime. Hoisting these to module level is identity-preserving — Python imports are idempotent against `sys.modules`.

## Files / subsystems touched

- `python/turboapi/request_handler.py` — added two module-level imports; removed 3 in-closure `parse_qs` imports and collapsed 7 `try: from turboapi.exceptions import HTTPException ... except ImportError: pass` blocks down to the bare `isinstance` check (the `ImportError` wrapper becomes dead code once the import is module-level).
- `benchmarks/bench_handler_dispatch.py` — new isolated microbench targeting `create_fast_handler` dispatch in 4 call shapes (noargs / pathonly / pathqs / patherr). Needed because end-to-end `bench_regression.py` has ~15-20% run-to-run noise that would hide a 5-7% Python-side win.

No public API change. No dependency change. No \`uv.lock\` change.

## Red-to-green

### Microbench (the load-bearing artifact)

\`.venv314t/bin/python benchmarks/bench_handler_dispatch.py\`, n=200k × 5 runs, free-threaded 3.14t, M-series macOS:

\`\`\`
case       before_us  after_us  delta
noargs     0.654      0.641     -2.0%   <- control (no import on hot path)
pathonly   0.903      0.891     -1.3%   <- control (no parse_qs)
pathqs     2.130      2.016     -5.4%   <- parse_qs path
patherr    1.248      1.158     -7.2%   <- HTTPException exception path
\`\`\`

Targeted dispatch paths drop 5-7%; controls flat (within run-to-run noise). The signal pattern (controls flat, targets faster) matches the predicted shape of the change.

### Nearby non-regression — macro HTTP throughput

\`BENCH_DURATION=5 PYTHON_GIL=0 .venv314t/bin/python benchmarks/bench_regression.py\`:

\`\`\`
                          before req/s  after req/s
GET /health               163,611       161,766     (-1.1%)
GET /                     162,639       162,550     (-0.05%)
GET /json                 163,663       162,110     (-0.9%)
GET /users/123            162,161       161,378     (-0.5%)
POST /items               155,671       157,034     (+0.9%)
GET /status201            162,308       162,859     (+0.3%)
AVG                       161,675       161,283     (-0.24%)
\`\`\`

Inside the documented ~15-20% run-to-run noise; macro path unaffected (these endpoints don't take query strings, so they don't even exercise the hoisted \`parse_qs\` path — they're a pure non-regression check).

## Tests run

\`\`\`
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv314t/bin/python -m pytest -q \\
  tests/test_async_handlers.py \\
  tests/test_request_parsing.py \\
  tests/test_annotated_depends.py \\
  tests/test_post_body_parsing.py
\`\`\`

Result: **24 passed** in 35.92s. Pre-existing \`PytestReturnNotNoneWarning\`s are unchanged by this PR.

## Checklist

- Linked issue: #147 (sub-task of #42).
- Rebased onto current \`main\`: yes (branched from \`main\` at \`3a3d367\`).
- Generated files / lockfiles changed: no. \`uv.lock\`, \`.zig-cache/\`, \`zig-out/\` untouched. The \`zig/zig-pkg/dhi-...\` build artifact was explicitly NOT staged.
- Dependency surface changed: no.
- Bench layer declared: HTTP-only (macro) + driver-only Python microbench (new). Caches: stdlib defaults. Cold/warm: warmed steady-state (microbench has 2k-iter warmup, macro is 5s wrk run). Number of runs: 5 for microbench, 1 for macro. Machine: local M-series macOS Apple Silicon, free-threaded CPython 3.14.3+freethreaded.
- Submission matches \`CONTRIBUTING.md\`: confirmed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justrach/turboapi/pull/148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->