### PR TITLE
fix: stale version-sync guard fails CI on every PR since 1.0.28

### DIFF
--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -31,5 +31,14 @@ def test_release_versions_are_in_sync():
 
 
 def test_release_version_bumped_past_bad_1_0_25_publish():
-    """This release must move past the broken 1.0.25/1.0.26 artifact publishes."""
-    assert _read_pyproject_version() == "1.0.27"
+    """This release must move past the broken 1.0.25/1.0.26 artifact publishes.
+
+    Compares as a tuple of integers so the guard keeps holding through
+    future patch / minor / major bumps without needing per-release edits.
+    """
+    version = _read_pyproject_version()
+    parts = tuple(int(p) for p in version.split(".")[:3])
+    assert parts >= (1, 0, 27), (
+        f"version {version} must be >= 1.0.27 (skipping the broken "
+        f"1.0.25 / 1.0.26 publishes)"
+    )


### PR DESCRIPTION
Closes #153.

## Summary

\`tests/test_release_version_sync.py::test_release_version_bumped_past_bad_1_0_25_publish\` hardcoded \`== \"1.0.27\"\`. The intent is to keep version past the broken 1.0.25 / 1.0.26 publishes, but equality means it fails the moment the version is bumped past 1.0.27.

Current main is at 1.0.29; CI on PR #148 and #152 (and any other open PR) hit this on macOS:

\`\`\`
FAILED tests/test_release_version_sync.py::test_release_version_bumped_past_bad_1_0_25_publish
  AssertionError: assert '1.0.29' == '1.0.27'
\`\`\`

Switch to a tuple-of-ints \`>=\` compare so the guard keeps holding through future bumps without per-release edits. Stdlib only — no new deps.

## Files / subsystems touched

- \`tests/test_release_version_sync.py\` — \`test_release_version_bumped_past_bad_1_0_25_publish\` body rewritten (3 lines removed, 12 added).

## Red-to-green

### Before

\`\`\`
$ .venv314t/bin/python -m pytest -q tests/test_release_version_sync.py
FAILED tests/test_release_version_sync.py::test_release_version_bumped_past_bad_1_0_25_publish - AssertionError: assert '1.0.29' == '1.0.27'
1 failed, 1 passed in 0.02s
\`\`\`

### After

\`\`\`
$ .venv314t/bin/python -m pytest -q tests/test_release_version_sync.py
..
2 passed in 0.01s
\`\`\`

Other test in the same file (\`test_release_versions_are_in_sync\`) still passes — confirms the fix didn't regress the sibling guard.

## Tests run

\`\`\`
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv314t/bin/python -m pytest -q tests/test_release_version_sync.py
\`\`\`

Result: **2 passed** in 0.01s.

## Checklist

- Linked issue: #153.
- Rebased onto current \`main\`: yes (branched off \`main\` at \`3a3d367\`).
- Generated files / lockfiles changed: no.
- Dependency surface changed: no.
- Submission matches \`CONTRIBUTING.md\`: confirmed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justrach/turboapi/pull/154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->