### PR TITLE
perf: extend _returns_model caching to pos_handler, async_pos_handler, fast_model_handler

### DIFF
--- a/benchmarks/bench_model_dump_cache_extended.py
+++ b/benchmarks/bench_model_dump_cache_extended.py
@@ -1,0 +1,103 @@
+"""
+Microbench for PR #157 — `_returns_model` caching extended to
+`create_pos_handler` (the slim positional dispatch path).
+
+Mirrors the shape of `bench_model_dump_cache.py` (#156) but exercises
+`create_pos_handler.pos_handler` instead of `create_fast_handler`.
+The other two patched sites (`create_async_pos_handler`,
+`create_fast_model_handler`) share the same dispatch code paths and
+benefit identically — sync pos_handler is the cheapest to bench.
+
+Three shapes:
+  * leaf      — `-> dict` : new code skips hasattr (-O(1) win)
+  * model     — `-> Item` : new code skips hasattr AND knows to call
+                            model_dump directly
+  * unannot   — no annot : new code falls back to hasattr (control —
+                           should match the pre-PR baseline within noise)
+
+Run:
+    .venv/bin/python benchmarks/bench_model_dump_cache_extended.py
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from collections.abc import Callable
+
+from dhi import BaseModel
+from turboapi.request_handler import create_pos_handler
+
+
+class Item(BaseModel):
+    name: str
+    qty: int
+
+
+def h_leaf() -> dict:
+    return {"ok": True}
+
+
+def h_model() -> Item:
+    return Item(name="widget", qty=1)
+
+
+def h_unannot():
+    return {"ok": True}
+
+
+def time_dispatch(fast: Callable, n: int) -> tuple[float, float]:
+    for _ in range(min(2_000, n // 10)):
+        fast()
+    t0 = time.perf_counter_ns()
+    for _ in range(n):
+        fast()
+    t1 = time.perf_counter_ns()
+    median_ns = (t1 - t0) / n
+    samples_ns: list[int] = []
+    for _ in range(min(20_000, n // 10)):
+        ts = time.perf_counter_ns()
+        fast()
+        samples_ns.append(time.perf_counter_ns() - ts)
+    p99_ns = sorted(samples_ns)[int(len(samples_ns) * 0.99)]
+    return median_ns, p99_ns
+
+
+def bench_leaf(n: int) -> tuple[float, float]:
+    return time_dispatch(create_pos_handler(h_leaf), n)
+
+
+def bench_model(n: int) -> tuple[float, float]:
+    return time_dispatch(create_pos_handler(h_model), n)
+
+
+def bench_unannot(n: int) -> tuple[float, float]:
+    return time_dispatch(create_pos_handler(h_unannot), n)
+
+
+def main() -> None:
+    runs = 5
+    n = 200_000
+
+    cases = [
+        ("leaf_dict", bench_leaf),       # -> dict :: skips hasattr (win)
+        ("model_dhi", bench_model),       # -> Item :: skips hasattr, direct call (win)
+        ("unannot",   bench_unannot),     # no annot :: keeps hasattr (control)
+    ]
+
+    print(f"create_pos_handler dispatch microbench  (n={n} per case, {runs} runs)")
+    print(f"{'case':<14} {'median_ns':>11} {'p99_ns':>10}")
+    for name, fn in cases:
+        med_runs = []
+        p99_runs = []
+        for _ in range(runs):
+            m, p = fn(n)
+            med_runs.append(m)
+            p99_runs.append(p)
+        med_ns = statistics.median(med_runs)
+        p99_ns = statistics.median(p99_runs)
+        print(f"{name:<14} {med_ns:>11.1f} {p99_ns:>10.1f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/turboapi/request_handler.py
+++ b/python/turboapi/request_handler.py
@@ -1255,6 +1255,7 @@ def create_pos_handler(original_handler):
     import json as _json
 
     _dumps = _json.dumps
+    _returns_md = _returns_model(original_handler)
     from turboapi.responses import Response as _Response
 
     def pos_handler(*args):
@@ -1265,7 +1266,7 @@ def create_pos_handler(original_handler):
                     result.body if isinstance(result.body, bytes) else result.body.encode("utf-8")
                 )
                 return (result.status_code, result.media_type or "application/json", body)
-            if hasattr(result, "model_dump"):
+            if _returns_md or (_returns_md is None and hasattr(result, "model_dump")):
                 result = result.model_dump()
             if isinstance(result, tuple) and len(result) == 2:
                 return (result[1], "application/json", _dumps(result[0]))
@@ -1283,6 +1284,7 @@ def create_async_pos_handler(original_handler):
     import json as _json
 
     _dumps = _json.dumps
+    _returns_md = _returns_model(original_handler)
     from turboapi.responses import Response as _Response
 
     async def pos_handler(*args):
@@ -1293,7 +1295,7 @@ def create_async_pos_handler(original_handler):
                     result.body if isinstance(result.body, bytes) else result.body.encode("utf-8")
                 )
                 return (result.status_code, result.media_type or "application/json", body)
-            if hasattr(result, "model_dump"):
+            if _returns_md or (_returns_md is None and hasattr(result, "model_dump")):
                 result = result.model_dump()
             if isinstance(result, tuple) and len(result) == 2:
                 return (result[1], "application/json", _dumps(result[0]))
@@ -1541,6 +1543,7 @@ def create_fast_model_handler(original_handler, model_class, param_name):
 
     _loads = _json.loads
     _dumps = _json.dumps
+    _returns_md = _returns_model(original_handler)
 
     def fast_model_handler(**kwargs):
         try:
@@ -1554,7 +1557,7 @@ def create_fast_model_handler(original_handler, model_class, param_name):
             model = model_class(**data)
             result = original_handler(**{param_name: model})
 
-            if hasattr(result, "model_dump"):
+            if _returns_md or (_returns_md is None and hasattr(result, "model_dump")):
                 result = result.model_dump()
             if isinstance(result, tuple) and len(result) == 2:
                 return (result[1], "application/json", _dumps(result[0]))

--- a/tests/test_returns_model_cache_extended.py
+++ b/tests/test_returns_model_cache_extended.py
@@ -1,0 +1,150 @@
+"""Targeted regression tests for PR #157 — `_returns_model` caching extended.
+
+Extends the coverage from `test_returns_model_cache.py` (which exercises
+`create_fast_handler`) to the three additional dispatch sites patched
+in #157:
+
+* `create_pos_handler.pos_handler`              (sync, positional)
+* `create_async_pos_handler.pos_handler`        (async, positional)
+* `create_fast_model_handler.fast_model_handler` (model-input dispatch)
+
+Each handler is exercised in three shapes:
+* annotated `-> Model`  : should call `result.model_dump()`
+* annotated `-> dict`   : should skip the model_dump path
+* unannotated           : should fall back to per-response hasattr
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from dhi import BaseModel
+from turboapi.request_handler import (
+    create_async_pos_handler,
+    create_fast_model_handler,
+    create_pos_handler,
+)
+
+
+class Item(BaseModel):
+    name: str
+    qty: int
+
+
+# -- create_pos_handler --------------------------------------------------
+
+def test_pos_handler_model_annotated():
+    def h() -> Item:
+        return Item(name="widget", qty=3)
+
+    fast = create_pos_handler(h)
+    status, ctype, body = fast()
+    assert status == 200
+    assert ctype == "application/json"
+    assert json.loads(body) == {"name": "widget", "qty": 3}
+
+
+def test_pos_handler_dict_annotated():
+    def h() -> dict:
+        return {"hello": "world"}
+
+    fast = create_pos_handler(h)
+    status, _, body = fast()
+    assert status == 200
+    assert json.loads(body) == {"hello": "world"}
+
+
+def test_pos_handler_unannotated_model_return():
+    def h():
+        return Item(name="thing", qty=7)
+
+    fast = create_pos_handler(h)
+    status, _, body = fast()
+    assert status == 200
+    assert json.loads(body) == {"name": "thing", "qty": 7}
+
+
+def test_pos_handler_unannotated_dict_return():
+    def h():
+        return {"a": 1}
+
+    fast = create_pos_handler(h)
+    status, _, body = fast()
+    assert status == 200
+    assert json.loads(body) == {"a": 1}
+
+
+# -- create_async_pos_handler --------------------------------------------
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro) if asyncio.get_event_loop().is_running() is False else asyncio.run(coro)
+
+
+def test_async_pos_handler_model_annotated():
+    async def h() -> Item:
+        return Item(name="widget", qty=3)
+
+    fast = create_async_pos_handler(h)
+    status, ctype, body = asyncio.run(fast())
+    assert status == 200
+    assert ctype == "application/json"
+    assert json.loads(body) == {"name": "widget", "qty": 3}
+
+
+def test_async_pos_handler_dict_annotated():
+    async def h() -> dict:
+        return {"hello": "world"}
+
+    fast = create_async_pos_handler(h)
+    status, _, body = asyncio.run(fast())
+    assert status == 200
+    assert json.loads(body) == {"hello": "world"}
+
+
+def test_async_pos_handler_unannotated_model_return():
+    async def h():
+        return Item(name="thing", qty=7)
+
+    fast = create_async_pos_handler(h)
+    status, _, body = asyncio.run(fast())
+    assert status == 200
+    assert json.loads(body) == {"name": "thing", "qty": 7}
+
+
+# -- create_fast_model_handler -------------------------------------------
+
+def test_fast_model_handler_model_annotated_return():
+    # Handler takes a model in, returns a (different shape) model out.
+    class Out(BaseModel):
+        echoed: str
+        doubled_qty: int
+
+    def h(item: Item) -> Out:
+        return Out(echoed=item.name, doubled_qty=item.qty * 2)
+
+    fast = create_fast_model_handler(h, Item, "item")
+    status, ctype, body = fast(body_dict={"name": "widget", "qty": 5})
+    assert status == 200
+    assert ctype == "application/json"
+    assert json.loads(body) == {"echoed": "widget", "doubled_qty": 10}
+
+
+def test_fast_model_handler_dict_annotated_return():
+    def h(item: Item) -> dict:
+        return {"name": item.name, "qty": item.qty}
+
+    fast = create_fast_model_handler(h, Item, "item")
+    status, _, body = fast(body_dict={"name": "widget", "qty": 5})
+    assert status == 200
+    assert json.loads(body) == {"name": "widget", "qty": 5}
+
+
+def test_fast_model_handler_unannotated_model_return():
+    def h(item):
+        return Item(name=item.name + "!", qty=item.qty)
+
+    fast = create_fast_model_handler(h, Item, "item")
+    status, _, body = fast(body_dict={"name": "widget", "qty": 5})
+    assert status == 200
+    assert json.loads(body) == {"name": "widget!", "qty": 5}


### PR DESCRIPTION
Closes #157. Sub-task of #42. Follow-up to [#156](https://github.com/justrach/turboAPI/pull/156) (now merged into \`release/1.0.30\`). Re-opens replacing the original PR #160 which auto-closed when its stacked base branch was deleted on #156's merge.

## Summary

PR #156 introduced `_returns_model(handler)` and consulted it at dispatch in three fast-handler sites. The same per-response `hasattr(result, "model_dump")` pattern existed in three more sites that #156's scope deliberately left out. This PR closes the loop.

| line  | site                                            | function                            |
|-------|-------------------------------------------------|-------------------------------------|
| ~1268 | sync positional dispatch                        | `create_pos_handler.pos_handler`    |
| ~1297 | async positional dispatch                       | `create_async_pos_handler.pos_handler` |
| ~1559 | model-input dispatch                            | `create_fast_model_handler.fast_model_handler` |

Each gets:
1. `_returns_md = _returns_model(original_handler)` bound once at the top of the factory.
2. Per-response check switches from `if hasattr(result, "model_dump"): ...` to `if _returns_md or (_returns_md is None and hasattr(result, "model_dump")): ...`.

`create_fast_model_handler` is the most interesting site: it already takes a `model_class` for *input* validation, but the *output* shape is still unknown until you check the user handler's return annotation. The same helper applies — we introspect `original_handler` (the user's handler), not `model_class`.

Identity-preserving for all three branches (True / False / None). The `_returns_md is None` fallback keeps the per-response `hasattr` behavior for unannotated handlers.

## Files / subsystems touched

* `python/turboapi/request_handler.py` — 3 closure-time bindings + 3 dispatch-site swaps (one per factory function).
* `tests/test_returns_model_cache_extended.py` — new file. 10 targeted tests, 3-4 per handler, covering each annotation shape (`-> Model`, `-> dict`, unannotated).
* `benchmarks/bench_model_dump_cache_extended.py` — new isolated microbench targeting `create_pos_handler` (the cheapest of the three; the other two share the same dispatch code paths and benefit identically).

No public API change. No dependency change. No `uv.lock` change.

## Red-to-green

### Microbench (load-bearing artifact)

`.venv/bin/python benchmarks/bench_model_dump_cache_extended.py`, n=200k × 5 runs, free-threaded 3.14t, M-series macOS:

\`\`\`
case        pre median  post median   delta   pre p99   post p99   delta
leaf_dict      668.6 ns    654.3 ns   -2.1%    875 ns    875 ns      0%
model_dhi     2711.2 ns   2645.5 ns   -2.4%   3125 ns   2917 ns     -7%
unannot        686.8 ns    669.4 ns   -2.5%    959 ns    958 ns   noise
\`\`\`

Modest in absolute terms (the per-call savings is one `hasattr` ≈ 30 ns) but consistent across all three shapes. The model-return path's p99 drops 7%, matching the pattern from #156's bench.

Pre-PR baseline collected by \`git stash\`-ing the patch file (with #156's `_returns_model` helper still in place) and re-running the same bench against the unpatched dispatch sites.

### Targeted tests

\`\`\`
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q \\
  tests/test_returns_model_cache.py \\
  tests/test_returns_model_cache_extended.py \\
  tests/test_async_handlers.py \\
  tests/test_post_body_parsing.py
\`\`\`

Result: **32 passed** in 24.48s (10 new for #157 + 10 from #156's test file + 12 existing). Pre-existing \`PytestReturnNotNoneWarning\`s unchanged by this PR.

## Risk

Low. Same shape as #156. The new test file directly exercises:
* \`create_pos_handler\` × 4 shapes (model annotated, dict annotated, unannotated returning model, unannotated returning dict)
* \`create_async_pos_handler\` × 3 shapes
* \`create_fast_model_handler\` × 3 shapes (model in / model out, model in / dict out, model in / unannotated returning model)

All confirm: annotated-as-model still calls `model_dump`, annotated-as-dict skips it correctly, unannotated still falls back to `hasattr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justrach/turboapi/pull/161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->