### PR TITLE
test: re-enable TestWebSocket + add SSE wire-format coverage (#146)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,7 @@ jobs:
 
       - name: Run tests (TurboAPI + TurboPG)
         run: |
-          DESELECT="--deselect tests/test_fastapi_parity.py::TestWebSocket::test_websocket_send_receive"
-          DESELECT="$DESELECT --deselect tests/test_fastapi_parity.py::TestWebSocket::test_websocket_send_json"
+          DESELECT=""
           if [ "$RUNNER_OS" = "macOS" ]; then
             DESELECT="$DESELECT --deselect tests/test_query_and_headers.py::test_query_parameters_comprehensive"
           fi

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -57,9 +57,7 @@ jobs:
 
       - name: Run tests
         run: |
-          python -m pytest tests/ -v --tb=short \
-            --deselect tests/test_fastapi_parity.py::TestWebSocket::test_websocket_send_receive \
-            --deselect tests/test_fastapi_parity.py::TestWebSocket::test_websocket_send_json
+          python -m pytest tests/ -v --tb=short
         # Linux x86_64 segfaults on Zig thread cleanup between tests (known issue)
         continue-on-error: ${{ matrix.os == 'ubuntu-latest' }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,7 @@ docker compose up --build
 
 ```bash
 # Python tests (requires Python 3.14t)
-uv run --python 3.14t python -m pytest tests/ -p no:anchorpy \
-  --deselect tests/test_fastapi_parity.py::TestWebSocket
+uv run --python 3.14t python -m pytest tests/ -p no:anchorpy
 
 # Zig unit tests (includes fuzz seed corpus)
 cd zig && zig build test
@@ -38,7 +37,6 @@ cd zig && zig build test --fuzz
 ```
 
 **Known test exclusions:**
-- WebSocket tests (`TestWebSocket`) — pre-existing failure, deselect
 - `anchorpy` plugin — causes import error, disable with `-p no:anchorpy`
 
 ## Benchmarks

--- a/tests/test_fastapi_parity.py
+++ b/tests/test_fastapi_parity.py
@@ -4,11 +4,11 @@ Tests cover: routing, params, responses, security, middleware, background tasks,
 WebSocket, exception handling, OpenAPI, TestClient, static files, lifespan, etc.
 """
 
+import asyncio
 import json
 import os
 import tempfile
 
-import pytest
 from turboapi import (
     APIKeyCookie,
     APIKeyHeader,
@@ -566,25 +566,29 @@ class TestWebSocket:
         assert exc.code == 1001
         assert exc.reason == "Going away"
 
-    @pytest.mark.asyncio
-    async def test_websocket_send_receive(self):
-        ws = WebSocket()
-        await ws.accept()
-        assert ws.client_state == "connected"
+    def test_websocket_send_receive(self):
+        async def _run():
+            ws = WebSocket()
+            await ws.accept()
+            assert ws.client_state == "connected"
 
-        await ws._receive_queue.put({"type": "text", "data": "hello"})
-        msg = await ws.receive_text()
-        assert msg == "hello"
+            await ws._receive_queue.put({"type": "text", "data": "hello"})
+            msg = await ws.receive_text()
+            assert msg == "hello"
 
-    @pytest.mark.asyncio
-    async def test_websocket_send_json(self):
-        ws = WebSocket()
-        await ws.accept()
-        await ws.send_json({"key": "value"})
+        asyncio.run(_run())
 
-        sent = await ws._send_queue.get()
-        assert sent["type"] == "text"
-        assert json.loads(sent["data"]) == {"key": "value"}
+    def test_websocket_send_json(self):
+        async def _run():
+            ws = WebSocket()
+            await ws.accept()
+            await ws.send_json({"key": "value"})
+
+            sent = await ws._send_queue.get()
+            assert sent["type"] == "text"
+            assert json.loads(sent["data"]) == {"key": "value"}
+
+        asyncio.run(_run())
 
 
 # ============================================================

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -1,0 +1,213 @@
+"""Tests for SSE (Server-Sent Events) wire format and EventSourceResponse.
+
+Covers `python/turboapi/sse.py`:
+* `ServerSentEvent` dataclass + `.encode()`
+* `format_sse_event` wire format
+* `EventSourceResponse` headers / media type / iterator wrapping
+
+Note: end-to-end streaming over the Zig HTTP server is NOT exercised here —
+the current Zig dispatch path sends `Response.body` directly and does not
+yet iterate `StreamingResponse.body_iterator()`. Tracking that gap in a
+follow-up issue. These tests lock in the parts that are functional today
+(everything below the transport layer).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from turboapi.sse import EventSourceResponse, ServerSentEvent, format_sse_event
+
+# ---------------------------------------------------------------------------
+# format_sse_event / ServerSentEvent.encode wire format
+# ---------------------------------------------------------------------------
+
+
+def test_format_data_only_string():
+    out = format_sse_event(ServerSentEvent(data="hello"))
+    assert out == "data: hello\n\n"
+
+
+def test_format_data_only_dict_serializes_json():
+    out = format_sse_event(ServerSentEvent(data={"a": 1, "b": "two"}))
+    # Single-line JSON → single `data:` line
+    assert out.startswith("data: ")
+    assert out.endswith("\n\n")
+    payload = out.removeprefix("data: ").removesuffix("\n\n")
+    assert json.loads(payload) == {"a": 1, "b": "two"}
+
+
+def test_format_data_multiline_string_emits_one_data_per_line():
+    out = format_sse_event(ServerSentEvent(data="line1\nline2\nline3"))
+    # Each newline-separated chunk becomes its own `data:` line
+    assert "data: line1" in out
+    assert "data: line2" in out
+    assert "data: line3" in out
+    assert out.endswith("\n\n")
+
+
+def test_format_event_name():
+    out = format_sse_event(ServerSentEvent(data="hi", event="update"))
+    assert "event: update\n" in out
+    assert "data: hi\n" in out
+
+
+def test_format_id_field():
+    out = format_sse_event(ServerSentEvent(data="hi", id="42"))
+    assert "id: 42\n" in out
+
+
+def test_format_id_can_be_int():
+    out = format_sse_event(ServerSentEvent(data="hi", id=99))
+    assert "id: 99\n" in out
+
+
+def test_format_retry_field():
+    out = format_sse_event(ServerSentEvent(data="hi", retry=3000))
+    assert "retry: 3000\n" in out
+
+
+def test_format_comment_only():
+    out = format_sse_event(ServerSentEvent(comment="ping"))
+    # Comments are `:` prefixed per the SSE spec.
+    assert out.startswith(": ping")
+    assert out.endswith("\n\n")
+
+
+def test_format_multiline_comment():
+    out = format_sse_event(ServerSentEvent(comment="line1\nline2"))
+    assert ": line1" in out
+    assert ": line2" in out
+
+
+def test_format_combined_fields_in_canonical_order():
+    out = format_sse_event(
+        ServerSentEvent(
+            data="payload",
+            event="msg",
+            id=7,
+            retry=1500,
+            comment="diagnostic",
+        )
+    )
+    # Field order per the sse.py implementation: comment → event → id → retry → data.
+    # Locking that order in so reorder regressions are visible.
+    lines = out.splitlines()
+    nonempty = [ln for ln in lines if ln]
+    assert nonempty[0].startswith(": ")
+    assert nonempty[1].startswith("event: ")
+    assert nonempty[2].startswith("id: ")
+    assert nonempty[3].startswith("retry: ")
+    assert nonempty[4].startswith("data: ")
+
+
+def test_encode_method_matches_format_function():
+    evt = ServerSentEvent(data={"x": 1}, event="e", id="1")
+    assert evt.encode() == format_sse_event(evt)
+
+
+def test_format_terminates_with_double_newline():
+    # SSE protocol requires \n\n to delimit events.
+    out = format_sse_event(ServerSentEvent(data="x"))
+    assert out.endswith("\n\n")
+
+
+# ---------------------------------------------------------------------------
+# EventSourceResponse construction
+# ---------------------------------------------------------------------------
+
+
+async def _gen_three():
+    yield ServerSentEvent(data="a")
+    yield ServerSentEvent(data="b")
+    yield ServerSentEvent(data="c")
+
+
+def test_event_source_response_sets_sse_headers():
+    resp = EventSourceResponse(_gen_three())
+    assert resp.media_type == "text/event-stream"
+    # SSE-required headers should be present:
+    assert resp.headers["content-type"] == "text/event-stream"
+    assert resp.headers["cache-control"] == "no-cache"
+    assert resp.headers["connection"] == "keep-alive"
+    # Disable nginx/proxy buffering so events flush immediately:
+    assert resp.headers["x-accel-buffering"] == "no"
+
+
+def test_event_source_response_status_code_default_200():
+    resp = EventSourceResponse(_gen_three())
+    assert resp.status_code == 200
+
+
+def test_event_source_response_custom_headers_merge():
+    resp = EventSourceResponse(_gen_three(), headers={"x-custom": "yes"})
+    assert resp.headers["x-custom"] == "yes"
+    # SSE defaults must not be overridden by partial header dict:
+    assert resp.headers["content-type"] == "text/event-stream"
+
+
+def test_event_source_response_iterates_events_and_encodes_each():
+    """Drain the wrapped iterator and confirm each yield is SSE-encoded."""
+    resp = EventSourceResponse(_gen_three(), ping_interval=999)
+
+    async def drain():
+        out = []
+        async for chunk in resp._wrap_with_ping(_gen_three()):
+            out.append(chunk)
+            if len(out) >= 3:
+                break
+        return out
+
+    chunks = asyncio.run(drain())
+    assert len(chunks) == 3
+    assert chunks[0] == "data: a\n\n"
+    assert chunks[1] == "data: b\n\n"
+    assert chunks[2] == "data: c\n\n"
+
+
+def test_event_source_response_auto_wraps_dict_as_data():
+    async def gen():
+        yield {"key": "val"}
+
+    resp = EventSourceResponse(gen(), ping_interval=999)
+
+    async def drain():
+        async for chunk in resp._wrap_with_ping(gen()):
+            return chunk
+
+    chunk = asyncio.run(drain())
+    assert chunk.startswith("data: ")
+    assert json.loads(chunk.removeprefix("data: ").removesuffix("\n\n")) == {"key": "val"}
+
+
+def test_event_source_response_auto_wraps_string_as_data():
+    async def gen():
+        yield "plain"
+
+    resp = EventSourceResponse(gen(), ping_interval=999)
+
+    async def drain():
+        async for chunk in resp._wrap_with_ping(gen()):
+            return chunk
+
+    chunk = asyncio.run(drain())
+    assert chunk == "data: plain\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Streaming-over-Zig integration gap (acknowledged, not executed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(
+    reason=(
+        "End-to-end SSE streaming over the Zig HTTP server is not yet wired up: "
+        "request_handler dispatches `Response.body` directly and does not iterate "
+        "StreamingResponse.body_iterator(). Tracked in follow-up issue."
+    )
+)
+def test_event_source_response_end_to_end_over_zig_server():
+    """Reserved placeholder — un-skip when the Zig dispatch path streams chunks."""
+    raise NotImplementedError


### PR DESCRIPTION
Closes part of #146 — gets the API-surface tests for WebSocket & SSE actually running. Real over-the-wire support for both is tracked in follow-up issues.

## Why this is scoped this way

Issue #146 asks about SSE & WebSocket implementation milestones. Investigation found:

- WebSocket: \`python/turboapi/websockets.py\` exposes the FastAPI-compatible API (\`@app.websocket\`, \`WebSocket.send_text/recv_text/...\`), but methods just push to in-process \`asyncio.Queue\`s. There is **zero** Zig-side support: no \`Connection: Upgrade\` detection, no Sec-WebSocket-Key handshake, no frame parser. \`zig/src/server.zig\` has no \`websocket\` / \`Upgrade\` references.
- SSE: \`python/turboapi/sse.py\` exposes \`EventSourceResponse\` extending \`StreamingResponse\`. \`StreamingResponse\` sets \`body = b\"\"\` and parks the iterator in \`_content_iterator\`. \`request_handler.py\` reads \`response.body\` directly and ships it — so SSE responses currently send **empty bodies**. \`zig/src/server.zig\` has no \`text/event-stream\` / \`StreamingResponse\` / chunked-transfer awareness.

Real fixes for both require new Zig-side dispatch paths (chunked transfer encoding for SSE; full WS upgrade + frame layer for WebSocket) — multi-PR efforts. This PR is the smaller piece that lands today: get the existing API-surface tests actually running and lock in the SSE wire-format helpers.

## Files / subsystems touched

- \`tests/test_fastapi_parity.py\` — \`TestWebSocket\`: rewrite the 2 \`async def\` tests to use \`asyncio.run()\` inside the body. The \`@pytest.mark.asyncio\` decorator required \`pytest-asyncio\` plugin which the project disables via \`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1\` / \`-p no:anchorpy\`. Both tests pass now without needing the plugin.
- \`.github/workflows/ci.yml\`, \`.github/workflows/pre-release.yml\`, \`CLAUDE.md\` — drop the \`--deselect TestWebSocket::*\` workarounds (4 deselect entries total). All 4 \`TestWebSocket\` tests now run as part of the regular suite.
- \`tests/test_sse.py\` — new file. **18 unit tests** covering the SSE wire-format helpers in \`python/turboapi/sse.py\`:
  - \`format_sse_event\` / \`ServerSentEvent.encode()\` across all field shapes (data string / dict / multiline, event, id, retry, comment, combined fields in canonical order, double-newline termination).
  - \`EventSourceResponse\` construction (SSE headers, status code, custom-header merge, async-iterator drain + auto-wrap of dict / string yields).
  Plus 1 placeholder \`pytest.skip\` for end-to-end SSE-over-Zig — un-skips when the Zig dispatch path streams chunks (tracked in follow-up).

No public API change. No dependency change. No \`uv.lock\` change.

## Tests run

\`\`\`
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q \\
  tests/test_sse.py tests/test_fastapi_parity.py
\`\`\`

Result: **108 passed, 1 skipped** (88 in \`test_fastapi_parity.py\` — up from 86 since the 2 WS tests are now collected; 18 new in \`test_sse.py\`; 1 skipped placeholder for the end-to-end SSE path).

## What this does NOT change

* Zig HTTP server still doesn't iterate \`StreamingResponse.body_iterator()\`. SSE responses through the Zig dispatch path still send empty bodies.
* \`WebSocket\` class still only manipulates in-process queues — no \`Connection: Upgrade\` handling in the Zig server. The decorator + API tests pass; over-the-wire WebSocket does not work.

Both gaps acknowledged in the new test file's docstring and module-level comment, and will be tracked in dedicated follow-up issues with concrete implementation plans.

## Checklist

- Linked issue: #146 (partial — closes the test enablement piece, not the full implementation).
- Rebased onto current \`release/1.0.30\`: yes.
- Generated files / lockfiles changed: no. \`uv.lock\`, \`.zig-cache/\`, \`zig-out/\` untouched.
- Dependency surface changed: no.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justrach/turboapi/pull/162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->