### PR TITLE
feat: real WebSocket support on Zig HTTP core (closes #114)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,10 +27,9 @@ docker compose up --build
 
 ```bash
 # Python tests (requires Python 3.14t)
-uv run --python 3.14t python -m pytest tests/ -p no:anchorpy \
-  --deselect tests/test_fastapi_parity.py::TestWebSocket
+uv run --python 3.14t python -m pytest tests/ -p no:anchorpy
 
-# Zig unit tests (includes fuzz seed corpus)
+# Zig unit tests (includes fuzz seed corpus + WebSocket codec)
 cd zig && zig build test
 
 # Zig continuous fuzzing (runs indefinitely)
@@ -38,7 +37,6 @@ cd zig && zig build test --fuzz
 ```
 
 **Known test exclusions:**
-- WebSocket tests (`TestWebSocket`) — pre-existing failure, deselect
 - `anchorpy` plugin — causes import error, disable with `-p no:anchorpy`
 
 ## Benchmarks

--- a/python/turboapi/main_app.py
+++ b/python/turboapi/main_app.py
@@ -201,9 +201,23 @@ class TurboAPI(Router):
                 data = await websocket.receive_text()
                 await websocket.send_text(f"Echo: {data}")
         """
-
         def decorator(func: Callable):
             self._websocket_routes[path] = func
+            # Register with the Zig server if it's running. The decorator may
+            # be invoked at module-import time (before app.run()) — in that
+            # case we keep _websocket_routes around and register lazily on
+            # run(). If a turbonet server instance already exists, register
+            # immediately so the route is live without an app.run() round-trip
+            # (useful in tests).
+            try:
+                import importlib.util
+
+                if importlib.util.find_spec("turboapi.turbonet") is not None:
+                    srv = getattr(self, "_turbonet_server", None)
+                    if srv is not None and hasattr(srv, "add_websocket_route"):
+                        srv.add_websocket_route(path, func)
+            except ImportError:
+                pass
             return func
 
         return decorator
@@ -444,10 +458,16 @@ class TurboAPI(Router):
             import turbonet
 
             server = turbonet.TurboServer(host, port)
+            self._turbonet_server = server
 
             # Register all routes
             for route in self.registry.get_routes():
                 server.add_route(route.method.value, route.path, route.handler)
+
+            # Register WebSocket routes registered via @app.websocket(...)
+            for ws_path, ws_handler in self._websocket_routes.items():
+                if hasattr(server, "add_websocket_route"):
+                    server.add_websocket_route(ws_path, ws_handler)
 
             print("\n[SERVER] Starting Zig server...")
             server.run()

--- a/python/turboapi/websockets.py
+++ b/python/turboapi/websockets.py
@@ -1,6 +1,17 @@
 """WebSocket support for TurboAPI.
 
-FastAPI-compatible WebSocket handling with decorators and connection management.
+FastAPI-compatible WebSocket API. Two modes:
+
+1. **In-memory mode** (default, used by parity tests). Push/pop on
+   asyncio.Queue. No real socket. Set by leaving `_zig_conn` as None.
+
+2. **Connected mode** (real). `_zig_conn` is a PyCapsule wrapping a Zig
+   `*WsConn`. `send_*` / `receive_*` call into the turbonet C extension's
+   FFI primitives (`_ws_send_text`, `_ws_send_bytes`, `_ws_recv`, `_ws_close`)
+   which read/write actual WebSocket frames on the underlying TCP socket.
+
+Both modes share the same public API so handlers don't need to know which
+they're in.
 """
 
 import asyncio
@@ -17,48 +28,93 @@ class WebSocketDisconnect(Exception):
         self.reason = reason
 
 
+def _turbonet():
+    """Lazy import of the compiled module — keeps in-memory mode working
+    even if turbonet hasn't been built (e.g. during unit tests)."""
+    try:
+        from turboapi import turbonet  # type: ignore
+    except ImportError:
+        return None
+    return turbonet
+
+
 class WebSocket:
     """WebSocket connection object.
 
-    Provides methods for sending and receiving messages over a WebSocket connection.
+    Provides methods for sending and receiving messages over a WebSocket
+    connection.
     """
 
     def __init__(self, scope: dict | None = None):
         self.scope = scope or {}
         self._accepted = False
         self._closed = False
+        # In-memory mode queues (used when _zig_conn is None).
         self._send_queue: asyncio.Queue = asyncio.Queue()
         self._receive_queue: asyncio.Queue = asyncio.Queue()
+        # Connected mode: PyCapsule wrapping the Zig *WsConn pointer.
+        # When set, send/receive go through FFI instead of queues.
+        self._zig_conn: Any = None
         self.client_state = "connecting"
         self.path_params: dict[str, Any] = {}
         self.query_params: dict[str, str] = {}
         self.headers: dict[str, str] = {}
+
+    @property
+    def _is_zig_backed(self) -> bool:
+        return self._zig_conn is not None
 
     async def accept(
         self,
         subprotocol: str | None = None,
         headers: dict[str, str] | None = None,
     ) -> None:
-        """Accept the WebSocket connection."""
+        """Accept the WebSocket connection.
+
+        In connected mode, the handshake was already completed in Zig before
+        this handler was invoked — `accept()` is essentially a no-op that
+        flips local state. In in-memory mode, just flips state.
+        """
         self._accepted = True
         self.client_state = "connected"
 
     async def close(self, code: int = 1000, reason: str | None = None) -> None:
         """Close the WebSocket connection."""
+        if self._closed:
+            return
         self._closed = True
         self.client_state = "disconnected"
+        if self._is_zig_backed:
+            t = _turbonet()
+            if t is not None:
+                try:
+                    t._ws_close(self._zig_conn, int(code), (reason or ""))
+                except Exception:
+                    pass
 
     async def send_text(self, data: str) -> None:
         """Send a text message."""
         if not self._accepted or self._closed:
             raise RuntimeError("WebSocket is not connected")
-        await self._send_queue.put({"type": "text", "data": data})
+        if self._is_zig_backed:
+            t = _turbonet()
+            if t is None:
+                raise RuntimeError("turbonet not available")
+            t._ws_send_text(self._zig_conn, data)
+        else:
+            await self._send_queue.put({"type": "text", "data": data})
 
     async def send_bytes(self, data: bytes) -> None:
         """Send a binary message."""
         if not self._accepted or self._closed:
             raise RuntimeError("WebSocket is not connected")
-        await self._send_queue.put({"type": "bytes", "data": data})
+        if self._is_zig_backed:
+            t = _turbonet()
+            if t is None:
+                raise RuntimeError("turbonet not available")
+            t._ws_send_bytes(self._zig_conn, bytes(data))
+        else:
+            await self._send_queue.put({"type": "bytes", "data": data})
 
     async def send_json(self, data: Any, mode: str = "text") -> None:
         """Send a JSON message."""
@@ -72,6 +128,20 @@ class WebSocket:
         """Receive a text message."""
         if self._closed:
             raise WebSocketDisconnect()
+        if self._is_zig_backed:
+            t = _turbonet()
+            if t is None:
+                raise RuntimeError("turbonet not available")
+            try:
+                type_str, data = t._ws_recv(self._zig_conn)
+            except RuntimeError as exc:
+                self._closed = True
+                self.client_state = "disconnected"
+                raise WebSocketDisconnect() from exc
+            if type_str == "bytes":
+                # Bytes arrived where text was expected — decode.
+                return data.decode("utf-8", errors="replace")
+            return data
         message = await self._receive_queue.get()
         if message.get("type") == "disconnect":
             raise WebSocketDisconnect(code=message.get("code", 1000))
@@ -81,6 +151,19 @@ class WebSocket:
         """Receive a binary message."""
         if self._closed:
             raise WebSocketDisconnect()
+        if self._is_zig_backed:
+            t = _turbonet()
+            if t is None:
+                raise RuntimeError("turbonet not available")
+            try:
+                type_str, data = t._ws_recv(self._zig_conn)
+            except RuntimeError as exc:
+                self._closed = True
+                self.client_state = "disconnected"
+                raise WebSocketDisconnect() from exc
+            if type_str == "text":
+                return data.encode("utf-8")
+            return data
         message = await self._receive_queue.get()
         if message.get("type") == "disconnect":
             raise WebSocketDisconnect(code=message.get("code", 1000))

--- a/python/turboapi/zig_integration.py
+++ b/python/turboapi/zig_integration.py
@@ -1165,6 +1165,12 @@ class ZigIntegratedTurboAPI(TurboAPI):
 
         try:
             if NATIVE_CORE_AVAILABLE:
+                # Register WebSocket routes registered via @app.websocket(...).
+                if hasattr(self.zig_server, "add_websocket_route"):
+                    for ws_path, ws_handler in self._websocket_routes.items():
+                        self.zig_server.add_websocket_route(ws_path, ws_handler)
+                        print(f"   WebSocket route: {ws_path}")
+
                 # Start the actual Zig server
                 print("\n[SERVER] Starting Zig HTTP server with zero overhead...")
                 self.zig_server.run()

--- a/tests/test_websocket_e2e.py
+++ b/tests/test_websocket_e2e.py
@@ -1,0 +1,258 @@
+"""End-to-end WebSocket tests against the real Zig HTTP core.
+
+Boots a turboAPI server in a subprocess, connects with the `websockets`
+library, and exercises:
+  - The in-Zig /ws-echo route (no Python in the loop)
+  - Python @app.websocket() handlers (FFI bridge)
+  - text / binary / JSON / ping / close
+  - large messages (>16-bit length)
+  - fragmented client messages
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+websockets = pytest.importorskip("websockets")
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PORT = 18920  # avoid clashes with other test servers
+
+
+@pytest.fixture(scope="module")
+def ws_server():
+    """Spawn a turboAPI server with WS routes and yield the base URL."""
+    script = textwrap.dedent(
+        f"""
+        from turboapi import TurboAPI
+        from turboapi.websockets import WebSocket, WebSocketDisconnect
+
+        app = TurboAPI(title="ws-e2e", version="0.0.1")
+        try:
+            app.configure_rate_limiting(enabled=False)
+        except Exception:
+            pass
+
+        @app.get("/ping")
+        def ping():
+            return {{"ok": True}}
+
+        @app.websocket("/ws")
+        async def echo_handler(ws: WebSocket):
+            await ws.accept()
+            try:
+                while True:
+                    msg = await ws.receive_text()
+                    await ws.send_text(f"py-echo:{{msg}}")
+            except WebSocketDisconnect:
+                pass
+
+        @app.websocket("/ws-bytes")
+        async def bytes_handler(ws: WebSocket):
+            await ws.accept()
+            try:
+                while True:
+                    data = await ws.receive_bytes()
+                    await ws.send_bytes(b"B:" + data)
+            except WebSocketDisconnect:
+                pass
+
+        @app.websocket("/ws-json")
+        async def json_handler(ws: WebSocket):
+            await ws.accept()
+            try:
+                while True:
+                    data = await ws.receive_json()
+                    data["server"] = "turboapi"
+                    await ws.send_json(data)
+            except WebSocketDisconnect:
+                pass
+
+        @app.websocket("/ws-close")
+        async def close_handler(ws: WebSocket):
+            await ws.accept()
+            await ws.send_text("hello")
+            await ws.close(code=1001, reason="going away")
+
+        if __name__ == "__main__":
+            app.run(host="127.0.0.1", port={PORT})
+        """
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    # Wait for port to come up.
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", PORT), timeout=0.2):
+                break
+        except OSError:
+            time.sleep(0.05)
+    else:
+        proc.terminate()
+        raise TimeoutError(f"ws server did not start on {PORT}")
+
+    yield f"127.0.0.1:{PORT}"
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+# ── Zig-only echo route (no Python in the loop) ──
+
+@pytest.mark.asyncio
+async def test_ws_echo_text_zig(ws_server: str) -> None:
+    async with websockets.connect(f"ws://{ws_server}/ws-echo") as ws:
+        await ws.send("hello")
+        assert await ws.recv() == "hello"
+
+
+@pytest.mark.asyncio
+async def test_ws_echo_binary_zig(ws_server: str) -> None:
+    async with websockets.connect(f"ws://{ws_server}/ws-echo") as ws:
+        await ws.send(b"\x00\xff\xab")
+        assert await ws.recv() == b"\x00\xff\xab"
+
+
+@pytest.mark.asyncio
+async def test_ws_echo_large_zig(ws_server: str) -> None:
+    """Exercise 16-bit length encoding."""
+    async with websockets.connect(f"ws://{ws_server}/ws-echo") as ws:
+        msg = "x" * 1000
+        await ws.send(msg)
+        reply = await ws.recv()
+        assert reply == msg
+
+
+@pytest.mark.asyncio
+async def test_ws_ping_pong_zig(ws_server: str) -> None:
+    async with websockets.connect(f"ws://{ws_server}/ws-echo") as ws:
+        pong = await ws.ping(b"abc")
+        await asyncio.wait_for(pong, timeout=2.0)
+        # Connection still alive after ping.
+        await ws.send("still here")
+        assert await ws.recv() == "still here"
+
+
+# ── Python handler routes (FFI bridge) ──
+
+@pytest.mark.asyncio
+async def test_ws_python_echo(ws_server: str) -> None:
+    async with websockets.connect(f"ws://{ws_server}/ws") as ws:
+        await ws.send("hello")
+        assert await ws.recv() == "py-echo:hello"
+        await ws.send("again")
+        assert await ws.recv() == "py-echo:again"
+
+
+@pytest.mark.asyncio
+async def test_ws_python_bytes(ws_server: str) -> None:
+    async with websockets.connect(f"ws://{ws_server}/ws-bytes") as ws:
+        await ws.send(b"abc")
+        assert await ws.recv() == b"B:abc"
+
+
+@pytest.mark.asyncio
+async def test_ws_python_json(ws_server: str) -> None:
+    async with websockets.connect(f"ws://{ws_server}/ws-json") as ws:
+        await ws.send(json.dumps({"q": "hi"}))
+        reply = json.loads(await ws.recv())
+        assert reply == {"q": "hi", "server": "turboapi"}
+
+
+@pytest.mark.asyncio
+async def test_ws_python_server_close(ws_server: str) -> None:
+    """Server initiates the close — client should see the close frame."""
+    async with websockets.connect(f"ws://{ws_server}/ws-close") as ws:
+        assert await ws.recv() == "hello"
+        # Next recv raises ConnectionClosedOK because server closed cleanly.
+        with pytest.raises(websockets.exceptions.ConnectionClosed):
+            await ws.recv()
+
+
+# ── Routing edge cases ──
+
+@pytest.mark.asyncio
+async def test_ws_unknown_path_returns_404(ws_server: str) -> None:
+    with pytest.raises(websockets.exceptions.InvalidStatus) as exc_info:
+        async with websockets.connect(f"ws://{ws_server}/no-such-route"):
+            pass
+    assert exc_info.value.response.status_code == 404
+
+
+# ── Fragmentation (Phase 6) ──
+
+@pytest.mark.asyncio
+async def test_ws_fragmented_message_reassembled(ws_server: str) -> None:
+    """Send a fragmented text message; server must reassemble before echo."""
+    # The `websockets` high-level API doesn't expose fragmentation directly,
+    # so we drive the protocol manually.
+
+    reader, writer = await asyncio.open_connection("127.0.0.1", PORT)
+    try:
+        # Send HTTP upgrade request manually.
+        key = "dGhlIHNhbXBsZSBub25jZQ=="  # 16-byte base64 == "the sample nonce"
+        req = (
+            f"GET /ws-echo HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{PORT}\r\n"
+            f"Upgrade: websocket\r\n"
+            f"Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key}\r\n"
+            f"Sec-WebSocket-Version: 13\r\n"
+            f"\r\n"
+        )
+        writer.write(req.encode())
+        await writer.drain()
+
+        # Read 101 response.
+        line = await reader.readline()
+        assert b"101" in line, line
+        # Drain headers.
+        while True:
+            hdr = await reader.readline()
+            if hdr in (b"\r\n", b"", b"\n"):
+                break
+
+        # Send fragmented text "hello world" as ["hello ", "world"] with
+        # FIN=0 on first frame, FIN=1 + continuation on second.
+        def make_frame(fin: bool, opcode: int, payload: bytes, mask: bytes = b"\x01\x02\x03\x04") -> bytes:
+            b0 = (0x80 if fin else 0) | opcode
+            assert len(payload) <= 125  # keep it simple for the test
+            b1 = 0x80 | len(payload)
+            masked = bytes(p ^ mask[i & 3] for i, p in enumerate(payload))
+            return bytes([b0, b1]) + mask + masked
+
+        writer.write(make_frame(fin=False, opcode=0x1, payload=b"hello "))
+        writer.write(make_frame(fin=True, opcode=0x0, payload=b"world"))
+        await writer.drain()
+
+        # Read the echoed frame back.
+        # Expect: FIN=1, text, len=11, "hello world".
+        hdr = await reader.readexactly(2)
+        assert hdr[0] == 0x81, f"expected FIN+text, got {hdr[0]:#x}"
+        assert hdr[1] == 11, f"expected len=11, got {hdr[1]}"
+        body = await reader.readexactly(11)
+        assert body == b"hello world", body
+    finally:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass

--- a/zig/src/main.zig
+++ b/zig/src/main.zig
@@ -8,6 +8,7 @@ const response = @import("response.zig");
 const server = @import("server.zig");
 pub const router = @import("turboapi-core").router;
 const db = @import("db.zig");
+pub const websocket = @import("websocket.zig");
 
 // ── Method table ────────────────────────────────────────────────────────────
 
@@ -42,6 +43,13 @@ var methods = [_]py.PyMethodDef{
     .{ .ml_name = "configure_rate_limiting", .ml_meth = @ptrCast(&server.configure_rate_limiting), .ml_flags = c.METH_VARARGS, .ml_doc = null },
     .{ .ml_name = "_server_configure_cors", .ml_meth = @ptrCast(&server.server_configure_cors), .ml_flags = c.METH_VARARGS, .ml_doc = null },
     .{ .ml_name = "_server_enable_response_cache", .ml_meth = @ptrCast(&server.server_enable_response_cache), .ml_flags = c.METH_NOARGS, .ml_doc = null },
+
+    // WebSocket functions
+    .{ .ml_name = "_server_add_websocket_route", .ml_meth = @ptrCast(&server.server_add_websocket_route), .ml_flags = c.METH_VARARGS, .ml_doc = null },
+    .{ .ml_name = "_ws_recv", .ml_meth = @ptrCast(&server.ws_recv), .ml_flags = c.METH_VARARGS, .ml_doc = null },
+    .{ .ml_name = "_ws_send_text", .ml_meth = @ptrCast(&server.ws_send_text), .ml_flags = c.METH_VARARGS, .ml_doc = null },
+    .{ .ml_name = "_ws_send_bytes", .ml_meth = @ptrCast(&server.ws_send_bytes), .ml_flags = c.METH_VARARGS, .ml_doc = null },
+    .{ .ml_name = "_ws_close", .ml_meth = @ptrCast(&server.ws_close), .ml_flags = c.METH_VARARGS, .ml_doc = null },
     // DB functions
     .{ .ml_name = "_db_configure", .ml_meth = @ptrCast(&db.db_configure), .ml_flags = c.METH_VARARGS, .ml_doc = null },
     .{ .ml_name = "_db_add_route", .ml_meth = @ptrCast(&db.db_add_route), .ml_flags = c.METH_VARARGS, .ml_doc = null },
@@ -123,6 +131,46 @@ const bootstrap_code: [*:0]const u8 =
     \\        _m._db_configure(conn_string, pool_size)
     \\    def add_db_route(self, method, path, op, table, pk_column, pk_param, columns):
     \\        _m._db_add_route(method, path, op, table, pk_column or "", pk_param or "", columns or "")
+    \\    def add_websocket_route(self, path, handler):
+    \\        _m._server_add_websocket_route(path, handler)
+    \\
+    \\def _ws_invoke_handler(handler, conn_capsule, path):
+    \\    """Entry point Zig calls when a WS connection is upgraded.
+    \\    Builds a WebSocket Python object wrapping the Zig connection capsule
+    \\    and runs the user's async handler to completion."""
+    \\    import asyncio
+    \\    try:
+    \\        from turboapi.websockets import WebSocket, WebSocketDisconnect
+    \\    except ImportError as exc:
+    \\        # Fallback minimal shim if turboapi.websockets isn't importable.
+    \\        class WebSocketDisconnect(Exception): pass
+    \\        class WebSocket:
+    \\            def __init__(self, scope=None):
+    \\                self.scope = scope or {}
+    \\                self._zig_conn = None
+    \\                self._accepted = False
+    \\                self._closed = False
+    \\    ws = WebSocket(scope={"path": path, "type": "websocket"})
+    \\    ws._zig_conn = conn_capsule
+    \\    # Handshake already completed by Zig before this helper runs.
+    \\    ws._accepted = True
+    \\    ws.client_state = "connected"
+    \\    try:
+    \\        coro = handler(ws)
+    \\        if asyncio.iscoroutine(coro):
+    \\            asyncio.run(coro)
+    \\    except WebSocketDisconnect:
+    \\        pass
+    \\    except Exception:
+    \\        import traceback
+    \\        traceback.print_exc()
+    \\    finally:
+    \\        if not ws._closed:
+    \\            try:
+    \\                _m._ws_close(conn_capsule, 1000, "")
+    \\            except Exception:
+    \\                pass
+    \\_m._ws_invoke_handler = _ws_invoke_handler
     \\
     \\class RequestContext:
     \\    def __init__(self):

--- a/zig/src/server.zig
+++ b/zig/src/server.zig
@@ -13,6 +13,7 @@ const multipart_mod = @import("multipart.zig");
 const logger = @import("logger.zig");
 const runtime = @import("runtime.zig");
 const telemetry = @import("telemetry.zig");
+const ws = @import("websocket.zig");
 
 const allocator = std.heap.c_allocator;
 const posix = std.posix;
@@ -1145,6 +1146,582 @@ fn handleConnection(stream: std.Io.net.Stream, tstate: ?*anyopaque) void {
     }
 }
 
+
+// ── WebSocket runtime ──────────────────────────────────────────────────────
+//
+// Connection model: each accepted TCP connection runs in the same thread as
+// the HTTP request handler. When `handleOneRequest` detects a valid WebSocket
+// upgrade request, it dispatches into `runWebSocketConnection` which loops
+// reading + writing frames until close. The HTTP thread is "consumed" by the
+// WebSocket for the life of the connection — this is the simplest viable
+// model and matches what FastAPI/Starlette do.
+
+const ECHO_PATH = "/ws-echo";
+
+/// Per-connection state for a live WebSocket. Allocated on the stack of
+/// `runWebSocketConnection`. The Python FFI layer (Phase 4) will get an
+/// opaque pointer to this struct.
+pub const WsConn = struct {
+    stream: std.Io.net.Stream,
+    /// Read buffer for incoming frames. Sized for typical messages; large
+    /// payloads spill to the heap-backed `read_overflow`.
+    read_buf: [16 * 1024]u8 = undefined,
+    read_len: usize = 0,
+    /// Heap buffer used when a single frame's payload exceeds the inline
+    /// buffer. Freed at conn teardown.
+    read_overflow: ?[]u8 = null,
+    /// Reassembly buffer for fragmented messages. Allocated on first
+    /// continuation, freed when message completes or connection closes.
+    fragment_buf: std.ArrayListUnmanaged(u8) = .empty,
+    fragment_opcode: ws.Opcode = .continuation,
+    /// True once we've seen a client close frame and replied with our own.
+    closing: bool = false,
+
+    pub const MAX_MESSAGE: usize = 16 * 1024 * 1024;
+
+    fn deinit(self: *WsConn) void {
+        if (self.read_overflow) |o| allocator.free(o);
+        self.fragment_buf.deinit(allocator);
+    }
+
+    /// Read more bytes from the socket into read_buf, appending. Returns
+    /// false if the peer closed.
+    fn fillRead(self: *WsConn) bool {
+        if (self.read_len >= self.read_buf.len) return true; // buffer full — caller must drain
+        const n = posix.read(self.stream.socket.handle, self.read_buf[self.read_len..]) catch return false;
+        if (n == 0) return false;
+        self.read_len += n;
+        return true;
+    }
+
+    fn consumeRead(self: *WsConn, n: usize) void {
+        if (n >= self.read_len) {
+            self.read_len = 0;
+            return;
+        }
+        std.mem.copyForwards(u8, self.read_buf[0..], self.read_buf[n..self.read_len]);
+        self.read_len -= n;
+    }
+
+    /// Write a complete server-to-client frame to the socket.
+    pub fn writeFrame(self: *WsConn, fin: bool, opcode: ws.Opcode, payload: []const u8) !void {
+        // Common case: small payload, stack buffer.
+        if (payload.len <= 8192) {
+            var buf: [8192 + 10]u8 = undefined;
+            const n = try ws.writeServerFrame(&buf, fin, opcode, payload);
+            try streamWriteAll(self.stream, buf[0..n]);
+            return;
+        }
+        // Large payload: allocate exact size.
+        const total = payload.len + 10;
+        const buf = allocator.alloc(u8, total) catch return error.OutOfMemory;
+        defer allocator.free(buf);
+        const n = try ws.writeServerFrame(buf, fin, opcode, payload);
+        try streamWriteAll(self.stream, buf[0..n]);
+    }
+
+    /// Send a close frame with the given code and reason. Marks closing=true.
+    /// Caller should typically return shortly after.
+    pub fn sendClose(self: *WsConn, code: u16, reason: []const u8) void {
+        if (self.closing) return;
+        self.closing = true;
+        var payload_buf: [128]u8 = undefined;
+        const reason_clamped = if (reason.len > 123) reason[0..123] else reason;
+        const payload_len = ws.writeClosePayload(&payload_buf, code, reason_clamped) catch return;
+        self.writeFrame(true, .close, payload_buf[0..payload_len]) catch return;
+    }
+};
+
+/// Result of WS upgrade attempt.
+const WsUpgradeOutcome = enum {
+    /// Not a WebSocket request — caller should continue normal HTTP dispatch.
+    not_websocket,
+    /// Was a WS request and we handled it (whether successfully or with an
+    /// error response). Caller should NOT continue normal dispatch.
+    handled,
+};
+
+/// Case-insensitive header lookup.
+fn findHeader(headers: []const HeaderPair, name: []const u8) ?[]const u8 {
+    for (headers) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, name)) return h.value;
+    }
+    return null;
+}
+
+/// Case-insensitive substring search in a comma-separated header value.
+/// e.g. value = "keep-alive, Upgrade" + needle = "upgrade" → true.
+fn headerContainsToken(value: []const u8, token: []const u8) bool {
+    var it = std.mem.tokenizeAny(u8, value, ", \t");
+    while (it.next()) |tok| {
+        if (std.ascii.eqlIgnoreCase(tok, token)) return true;
+    }
+    return false;
+}
+
+/// Send a minimal HTTP error response on the WebSocket-upgrade path. Used for
+/// malformed upgrade requests (missing key, bad version, etc.).
+fn sendUpgradeError(stream: std.Io.net.Stream, status_code: u16, reason: []const u8) void {
+    var buf: [256]u8 = undefined;
+    const formatted = std.fmt.bufPrint(&buf, "HTTP/1.1 {d} {s}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", .{ status_code, reason }) catch return;
+    streamWriteAll(stream, formatted) catch {};
+}
+
+/// If this looks like a WebSocket upgrade request and the path is registered,
+/// complete the handshake and run the connection. Returns whether we handled
+/// the request (caller should stop normal HTTP dispatch).
+fn tryWebSocketUpgrade(
+    stream: std.Io.net.Stream,
+    request_head: []const u8,
+    first_line_end: usize,
+    header_end_pos: usize,
+    method: []const u8,
+    path: []const u8,
+    tstate: ?*anyopaque,
+) WsUpgradeOutcome {
+    if (!std.mem.eql(u8, method, "GET")) return .not_websocket;
+
+    // Quick check: does the request mention "upgrade" anywhere in headers?
+    // Avoids parsing the full header list for normal GETs.
+    const upgrade_hint = std.mem.indexOfPosLinear(u8, request_head, first_line_end, "Upgrade:") != null or
+        std.mem.indexOfPosLinear(u8, request_head, first_line_end, "upgrade:") != null;
+    if (!upgrade_hint) return .not_websocket;
+
+    var headers = parseHeaders(request_head, first_line_end, header_end_pos);
+    defer headers.deinit(allocator);
+
+    const upgrade_h = findHeader(headers.items, "upgrade") orelse return .not_websocket;
+    if (!std.ascii.eqlIgnoreCase(std.mem.trim(u8, upgrade_h, " \t"), "websocket")) return .not_websocket;
+
+    // Past this point we're confident it's a WS upgrade attempt. Any further
+    // failures send 400/426 and consume the connection.
+
+    const conn_h = findHeader(headers.items, "connection") orelse {
+        sendUpgradeError(stream, 400, "Bad Request");
+        return .handled;
+    };
+    if (!headerContainsToken(conn_h, "upgrade")) {
+        sendUpgradeError(stream, 400, "Bad Request");
+        return .handled;
+    }
+
+    const version_h = findHeader(headers.items, "sec-websocket-version") orelse {
+        sendUpgradeError(stream, 400, "Bad Request");
+        return .handled;
+    };
+    if (!std.mem.eql(u8, std.mem.trim(u8, version_h, " \t"), "13")) {
+        // RFC §4.4: must respond with 426 and Sec-WebSocket-Version: 13.
+        var buf: [128]u8 = undefined;
+        const resp = std.fmt.bufPrint(&buf, "HTTP/1.1 426 Upgrade Required\r\nSec-WebSocket-Version: 13\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", .{}) catch return .handled;
+        streamWriteAll(stream, resp) catch {};
+        return .handled;
+    }
+
+    const key_h = findHeader(headers.items, "sec-websocket-key") orelse {
+        sendUpgradeError(stream, 400, "Bad Request");
+        return .handled;
+    };
+    const key = std.mem.trim(u8, key_h, " \t");
+
+    // Route check: is this path a registered WS endpoint? V1 hardcodes /ws-echo;
+    // Phase 4 will look up python_ws_routes here.
+    if (!isWebSocketPath(path)) {
+        sendUpgradeError(stream, 404, "Not Found");
+        return .handled;
+    }
+
+    // Handshake.
+    var accept_buf: [ws.ACCEPT_LEN]u8 = undefined;
+    _ = ws.computeAcceptKey(key, &accept_buf) catch {
+        sendUpgradeError(stream, 500, "Internal Server Error");
+        return .handled;
+    };
+    var resp_buf: [256]u8 = undefined;
+    const resp_len = ws.writeHandshakeResponse(&resp_buf, &accept_buf) catch {
+        sendUpgradeError(stream, 500, "Internal Server Error");
+        return .handled;
+    };
+    streamWriteAll(stream, resp_buf[0..resp_len]) catch return .handled;
+
+    // Run the connection.
+    runWebSocketConnection(stream, path, tstate) catch |err| {
+        logger.warn("[WS] connection ended with error: {}", .{err});
+    };
+    return .handled;
+}
+
+fn isWebSocketPath(path: []const u8) bool {
+    // V1: hardcoded echo route. Phase 4 replaces with a lookup in a Python-
+    // populated route map.
+    if (std.mem.eql(u8, path, ECHO_PATH)) return true;
+    if (getWebSocketRoutes().contains(path)) return true;
+    return false;
+}
+
+var ws_routes_map: ?std.StringHashMap(*c.PyObject) = null;
+
+fn getWebSocketRoutes() *std.StringHashMap(*c.PyObject) {
+    if (ws_routes_map == null) {
+        ws_routes_map = std.StringHashMap(*c.PyObject).init(allocator);
+    }
+    return &ws_routes_map.?;
+}
+
+/// Drive a live WebSocket connection. Reads frames, dispatches by opcode,
+/// auto-replies to ping with pong, echoes text/binary for /ws-echo, and
+/// completes the close handshake when requested.
+///
+/// Phase 4: extend this to call into Python via FFI for registered routes.
+/// Outcome of reading the next user-visible WS message. Control frames
+/// (ping/pong/close) are handled internally and never surface as a Message.
+const NextMessage = union(enum) {
+    text: []const u8, // borrow from conn.read_buf / fragment_buf
+    binary: []const u8,
+    closed,
+    protocol_error,
+};
+
+/// Read frames until we have a complete user message (text or binary), the
+/// peer closes, or a protocol error occurs. Pings are auto-replied with
+/// pongs; pongs are dropped; close frames trigger close handshake.
+///
+/// On success the returned slice points into the conn's read_buf (for
+/// single-frame messages) or fragment_buf (for reassembled messages). The
+/// caller MUST consume the message before the next call (the buffers are
+/// reused).
+fn wsReadNextMessage(conn: *WsConn) NextMessage {
+    while (!conn.closing) {
+        if (conn.read_len < 2) {
+            if (!conn.fillRead()) return .closed;
+            continue;
+        }
+
+        const frame = ws.parseServerFrame(conn.read_buf[0..conn.read_len], WsConn.MAX_MESSAGE) catch |err| switch (err) {
+            ws.ParseError.Incomplete => {
+                if (!conn.fillRead()) return .closed;
+                continue;
+            },
+            ws.ParseError.PayloadTooLarge => {
+                conn.sendClose(1009, "message too big");
+                return .protocol_error;
+            },
+            else => {
+                conn.sendClose(1002, "protocol error");
+                return .protocol_error;
+            },
+        };
+
+        switch (frame.opcode) {
+            .ping => {
+                conn.writeFrame(true, .pong, frame.payload) catch return .closed;
+                conn.consumeRead(frame.consumed);
+            },
+            .pong => {
+                conn.consumeRead(frame.consumed);
+            },
+            .close => {
+                conn.sendClose(1000, "");
+                conn.consumeRead(frame.consumed);
+                return .closed;
+            },
+            .text, .binary => {
+                if (!frame.fin) {
+                    conn.fragment_opcode = frame.opcode;
+                    conn.fragment_buf.appendSlice(allocator, frame.payload) catch {
+                        conn.sendClose(1009, "fragment too big");
+                        return .protocol_error;
+                    };
+                    conn.consumeRead(frame.consumed);
+                } else {
+                    const op = frame.opcode;
+                    const payload = frame.payload;
+                    const consumed = frame.consumed;
+                    // We need to return a stable slice. Copy into fragment_buf
+                    // so the slice survives the upcoming consumeRead().
+                    conn.fragment_buf.clearRetainingCapacity();
+                    conn.fragment_buf.appendSlice(allocator, payload) catch return .protocol_error;
+                    conn.consumeRead(consumed);
+                    return switch (op) {
+                        .text => .{ .text = conn.fragment_buf.items },
+                        .binary => .{ .binary = conn.fragment_buf.items },
+                        else => unreachable,
+                    };
+                }
+            },
+            .continuation => {
+                if (conn.fragment_buf.items.len == 0) {
+                    conn.sendClose(1002, "unexpected continuation");
+                    return .protocol_error;
+                }
+                conn.fragment_buf.appendSlice(allocator, frame.payload) catch {
+                    conn.sendClose(1009, "fragment too big");
+                    return .protocol_error;
+                };
+                const op = conn.fragment_opcode;
+                const finalize = frame.fin;
+                conn.consumeRead(frame.consumed);
+                if (finalize) {
+                    return switch (op) {
+                        .text => .{ .text = conn.fragment_buf.items },
+                        .binary => .{ .binary = conn.fragment_buf.items },
+                        else => .protocol_error,
+                    };
+                }
+            },
+            else => {
+                conn.sendClose(1002, "unsupported opcode");
+                return .protocol_error;
+            },
+        }
+    }
+    return .closed;
+}
+
+/// Drive a live WebSocket connection. Dispatches to either the in-Zig echo
+/// loop (for /ws-echo) or the Python handler invoke path.
+fn runWebSocketConnection(stream: std.Io.net.Stream, path: []const u8, tstate: ?*anyopaque) !void {
+    var conn = WsConn{ .stream = stream };
+    defer conn.deinit();
+
+    if (std.mem.eql(u8, path, ECHO_PATH)) {
+        runEchoLoop(&conn);
+        return;
+    }
+
+    const handler = getWebSocketRoutes().get(path) orelse {
+        conn.sendClose(1011, "no handler");
+        return;
+    };
+
+    runPythonHandler(&conn, handler, path, tstate);
+}
+
+fn runEchoLoop(conn: *WsConn) void {
+    while (!conn.closing) {
+        const msg = wsReadNextMessage(conn);
+        switch (msg) {
+            .text => |t| conn.writeFrame(true, .text, t) catch return,
+            .binary => |b| conn.writeFrame(true, .binary, b) catch return,
+            .closed, .protocol_error => return,
+        }
+    }
+}
+
+/// Invoke a Python WS handler. The handler signature is `async def f(ws)`.
+/// We construct a WebSocket Python object wrapping a PyCapsule that holds
+/// the *WsConn pointer, then call into the Python bootstrap helper
+/// `_ws_invoke_handler` which runs the coroutine.
+fn runPythonHandler(conn: *WsConn, handler: *c.PyObject, path: []const u8, tstate: ?*anyopaque) void {
+    // handleOneRequest runs without GIL by default; each Python-calling helper
+    // acquires it. Do the same here, then drop it again when the handler
+    // returns so subsequent FFI calls (which release+reacquire) can interleave
+    // properly during the connection's lifetime.
+    py.PyEval_AcquireThread(tstate);
+    defer py.PyEval_ReleaseThread(tstate);
+
+    // Make a capsule from the conn pointer. Python side passes it back into
+    // ws_recv/ws_send/ws_close.
+    const capsule_name: [*:0]const u8 = "turbonet.WsConn";
+    const capsule = c.PyCapsule_New(@ptrCast(conn), capsule_name, null) orelse {
+        c.PyErr_Print();
+        conn.sendClose(1011, "internal error");
+        return;
+    };
+    defer c.Py_DecRef(capsule);
+
+    // Find the bootstrap-installed helper on the turbonet module:
+    // `_ws_invoke_handler(handler, capsule, path)`.
+    const turbonet_mod = c.PyImport_ImportModule("turboapi.turbonet") orelse blk: {
+        c.PyErr_Clear();
+        break :blk c.PyImport_ImportModule("turbonet") orelse {
+            c.PyErr_Print();
+            conn.sendClose(1011, "internal error");
+            return;
+        };
+    };
+    defer c.Py_DecRef(turbonet_mod);
+    invokeHelper(turbonet_mod, handler, capsule, path);
+
+    // Handler returned (or raised). If it didn't close the connection itself,
+    // send a clean close now.
+    if (!conn.closing) conn.sendClose(1000, "");
+}
+
+fn invokeHelper(mod: *c.PyObject, handler: *c.PyObject, capsule: *c.PyObject, path: []const u8) void {
+    const helper = c.PyObject_GetAttrString(mod, "_ws_invoke_handler") orelse {
+        c.PyErr_Print();
+        return;
+    };
+    defer c.Py_DecRef(helper);
+
+    const py_path = py.newString(path) orelse {
+        c.PyErr_Print();
+        return;
+    };
+    defer c.Py_DecRef(py_path);
+
+    const args = c.PyTuple_Pack(3, handler, capsule, py_path) orelse {
+        c.PyErr_Print();
+        return;
+    };
+    defer c.Py_DecRef(args);
+
+    const result = c.PyObject_Call(helper, args, null);
+    if (result) |r| {
+        c.Py_DecRef(r);
+    } else {
+        c.PyErr_Print();
+    }
+}
+
+// ── WebSocket FFI ──────────────────────────────────────────────────────────
+//
+// Python-facing primitives, exposed via main.zig method table:
+//   _server_add_websocket_route(path, handler)
+//   _ws_recv(capsule) -> (type_str, data) | raises WebSocketDisconnect
+//   _ws_send_text(capsule, str)
+//   _ws_send_bytes(capsule, bytes)
+//   _ws_close(capsule, code, reason)
+//
+// Each FFI call extracts the WsConn pointer from the capsule, releases the
+// GIL around blocking I/O, then re-acquires before returning a Python value.
+
+const WS_CAPSULE_NAME: [*:0]const u8 = "turbonet.WsConn";
+
+inline fn capsuleToConn(capsule_obj: ?*c.PyObject) ?*WsConn {
+    if (capsule_obj == null) return null;
+    const raw = c.PyCapsule_GetPointer(capsule_obj, WS_CAPSULE_NAME) orelse return null;
+    return @ptrCast(@alignCast(raw));
+}
+
+pub fn server_add_websocket_route(_: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    var path: [*c]const u8 = null;
+    var handler: ?*c.PyObject = null;
+    if (c.PyArg_ParseTuple(args, "sO", &path, &handler) == 0) return null;
+    const path_s = std.mem.span(path);
+    const path_owned = allocator.dupe(u8, path_s) catch {
+        py.setError("ws route alloc failed", .{});
+        return null;
+    };
+    c.Py_IncRef(handler.?);
+
+    var ws_routes = getWebSocketRoutes();
+    if (ws_routes.fetchPut(path_owned, handler.?) catch null) |old| {
+        // Replacing an existing route — free the old key + decref old handler.
+        allocator.free(path_owned);
+        c.Py_DecRef(old.value);
+        _ = ws_routes.put(old.key, handler.?) catch {};
+    }
+    return py.pyNone();
+}
+
+/// Block reading the next user-visible WS message. Returns a 2-tuple
+/// (type_str, data) where type_str is "text" or "bytes". Raises a Python
+/// RuntimeError on disconnect (Python side translates to WebSocketDisconnect).
+pub fn ws_recv(_: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    var capsule_obj: ?*c.PyObject = null;
+    if (c.PyArg_ParseTuple(args, "O", &capsule_obj) == 0) return null;
+    const conn = capsuleToConn(capsule_obj) orelse {
+        py.setError("invalid ws capsule", .{});
+        return null;
+    };
+
+    const save = py.PyEval_SaveThread();
+    const msg = wsReadNextMessage(conn);
+    py.PyEval_RestoreThread(save);
+
+    switch (msg) {
+        .text => |t| {
+            const type_str = py.newString("text") orelse return null;
+            const data = py.newString(t) orelse {
+                c.Py_DecRef(type_str);
+                return null;
+            };
+            return c.PyTuple_Pack(2, type_str, data);
+        },
+        .binary => |b| {
+            const type_str = py.newString("bytes") orelse return null;
+            const data = py.newBytes(b) orelse {
+                c.Py_DecRef(type_str);
+                return null;
+            };
+            return c.PyTuple_Pack(2, type_str, data);
+        },
+        .closed => {
+            // Signal disconnect to Python — RuntimeError, translated by the
+            // Python helper into WebSocketDisconnect.
+            c.PyErr_SetString(c.PyExc_RuntimeError, "websocket disconnect");
+            return null;
+        },
+        .protocol_error => {
+            c.PyErr_SetString(c.PyExc_RuntimeError, "websocket protocol error");
+            return null;
+        },
+    }
+}
+
+pub fn ws_send_text(_: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    var capsule_obj: ?*c.PyObject = null;
+    var text: [*c]const u8 = null;
+    var text_len: c.Py_ssize_t = 0;
+    if (c.PyArg_ParseTuple(args, "Os#", &capsule_obj, &text, &text_len) == 0) return null;
+    const conn = capsuleToConn(capsule_obj) orelse {
+        py.setError("invalid ws capsule", .{});
+        return null;
+    };
+
+    const slice = if (text_len > 0) text[0..@intCast(text_len)] else "";
+    const save = py.PyEval_SaveThread();
+    conn.writeFrame(true, .text, slice) catch {
+        py.PyEval_RestoreThread(save);
+        c.PyErr_SetString(c.PyExc_RuntimeError, "ws write failed");
+        return null;
+    };
+    py.PyEval_RestoreThread(save);
+    return py.pyNone();
+}
+
+pub fn ws_send_bytes(_: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    var capsule_obj: ?*c.PyObject = null;
+    var data: [*c]const u8 = null;
+    var data_len: c.Py_ssize_t = 0;
+    if (c.PyArg_ParseTuple(args, "Oy#", &capsule_obj, &data, &data_len) == 0) return null;
+    const conn = capsuleToConn(capsule_obj) orelse {
+        py.setError("invalid ws capsule", .{});
+        return null;
+    };
+
+    const slice = if (data_len > 0) data[0..@intCast(data_len)] else "";
+    const save = py.PyEval_SaveThread();
+    conn.writeFrame(true, .binary, slice) catch {
+        py.PyEval_RestoreThread(save);
+        c.PyErr_SetString(c.PyExc_RuntimeError, "ws write failed");
+        return null;
+    };
+    py.PyEval_RestoreThread(save);
+    return py.pyNone();
+}
+
+pub fn ws_close(_: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) ?*c.PyObject {
+    var capsule_obj: ?*c.PyObject = null;
+    var code: c_int = 1000;
+    var reason: [*c]const u8 = null;
+    var reason_len: c.Py_ssize_t = 0;
+    if (c.PyArg_ParseTuple(args, "Oi|s#", &capsule_obj, &code, &reason, &reason_len) == 0) return null;
+    const conn = capsuleToConn(capsule_obj) orelse {
+        py.setError("invalid ws capsule", .{});
+        return null;
+    };
+
+    const reason_slice = if (reason_len > 0 and reason != null) reason[0..@intCast(reason_len)] else "";
+    const save = py.PyEval_SaveThread();
+    conn.sendClose(@intCast(code), reason_slice);
+    py.PyEval_RestoreThread(save);
+    return py.pyNone();
+}
+
+
+
 fn handleOneRequest(stream: std.Io.net.Stream, tstate: ?*anyopaque) !void {
     // Phase 1: Read headers into a fixed buffer (headers are typically < 8KB)
     var header_buf: [8192]u8 = undefined;
@@ -1183,6 +1760,16 @@ fn handleOneRequest(stream: std.Io.net.Stream, tstate: ?*anyopaque) !void {
     const q_idx = std.mem.indexOf(u8, raw_path, "?");
     const path = if (q_idx) |i| raw_path[0..i] else raw_path;
     const query_string = if (q_idx) |i| raw_path[i + 1 ..] else "";
+
+    // ── WebSocket upgrade short-circuit ─────────────────────────────────
+    // Catches GET requests with Upgrade: websocket BEFORE the normal router
+    // lookup. WS routes are stored in a separate map (getWebSocketRoutes())
+    // populated by the Python `@app.websocket(...)` decorator, plus the
+    // hardcoded /ws-echo demo route.
+    switch (tryWebSocketUpgrade(stream, request_head, first_line_end, he, method, path, tstate)) {
+        .handled => return,
+        .not_websocket => {},
+    }
 
     // Phase 3: Route match EARLY — before header parsing, so fast handlers
     // can skip the expensive parseHeaders + body read entirely.

--- a/zig/src/websocket.zig
+++ b/zig/src/websocket.zig
@@ -249,7 +249,7 @@ test "parse: smallest text frame from client" {
 test "parse: 16-bit length encoding" {
     var payload: [200]u8 = undefined;
     @memset(&payload, 'A');
-    var buf: [206]u8 = undefined;
+    var buf: [208]u8 = undefined;
     buf[0] = 0x81;
     buf[1] = 0x80 | 126;
     std.mem.writeInt(u16, buf[2..4], 200, .big);
@@ -261,7 +261,7 @@ test "parse: 16-bit length encoding" {
 
     const frame = try parseServerFrame(&buf, PARSE_DEFAULT_MAX_PAYLOAD);
     try std.testing.expectEqual(@as(usize, 200), frame.payload.len);
-    try std.testing.expectEqual(@as(usize, 206), frame.consumed);
+    try std.testing.expectEqual(@as(usize, 208), frame.consumed);
 }
 
 test "parse: incomplete returns error.Incomplete" {

--- a/zig/src/websocket.zig
+++ b/zig/src/websocket.zig
@@ -1,0 +1,342 @@
+// RFC 6455 WebSocket frame codec + handshake helpers.
+//
+// Standalone module — no I/O, no Python, no globals. The runtime (server.zig)
+// owns the socket and the connection lifecycle; this module just turns bytes
+// on the wire into Frames and back.
+//
+// Reference: https://www.rfc-editor.org/rfc/rfc6455
+
+const std = @import("std");
+const crypto = std.crypto;
+
+/// WebSocket frame opcodes (RFC 6455 §5.2).
+pub const Opcode = enum(u4) {
+    continuation = 0x0,
+    text = 0x1,
+    binary = 0x2,
+    // 0x3..0x7 reserved (non-control)
+    close = 0x8,
+    ping = 0x9,
+    pong = 0xA,
+    // 0xB..0xF reserved (control)
+    _,
+
+    pub fn isControl(self: Opcode) bool {
+        return @intFromEnum(self) >= 0x8;
+    }
+};
+
+/// Parsed WebSocket frame. The `payload` slice points into the caller's read
+/// buffer (after masking has been applied in place if the frame was masked).
+pub const Frame = struct {
+    fin: bool,
+    rsv1: bool = false,
+    rsv2: bool = false,
+    rsv3: bool = false,
+    opcode: Opcode,
+    /// Unmasked payload. For masked frames, the source buffer has been XORed
+    /// in place — caller's buffer is mutated.
+    payload: []u8,
+    /// Total bytes consumed from the input buffer (header + payload).
+    consumed: usize,
+};
+
+/// Parse result.
+pub const ParseError = error{
+    /// Need more bytes — caller should read more from the socket and retry.
+    Incomplete,
+    /// Reserved bits set (no extensions negotiated).
+    ReservedBitsSet,
+    /// Control frame with payload > 125 bytes (RFC §5.5).
+    ControlFrameTooLarge,
+    /// Control frame fragmented (RFC §5.5).
+    FragmentedControlFrame,
+    /// Server received an unmasked client frame (RFC §5.1).
+    UnmaskedClientFrame,
+    /// Payload length exceeds caller-provided cap.
+    PayloadTooLarge,
+};
+
+pub const PARSE_DEFAULT_MAX_PAYLOAD: usize = 16 * 1024 * 1024; // 16 MB
+
+/// Parse a single frame from `buf`. On success, returns Frame with `payload`
+/// pointing into `buf` (XOR-demasked in place if necessary) and `consumed`
+/// indicating how many bytes were consumed. Returns Incomplete if `buf` does
+/// not yet contain a full frame.
+///
+/// Caller MUST pass a buffer they own (mutable) — masked frames are demasked
+/// in place. Server-side: this is always the case since the server never
+/// receives unmasked frames (RFC §5.1) and the input buffer is the read
+/// buffer.
+pub fn parseServerFrame(buf: []u8, max_payload: usize) ParseError!Frame {
+    if (buf.len < 2) return ParseError.Incomplete;
+
+    const b0 = buf[0];
+    const b1 = buf[1];
+
+    const fin = (b0 & 0x80) != 0;
+    const rsv1 = (b0 & 0x40) != 0;
+    const rsv2 = (b0 & 0x20) != 0;
+    const rsv3 = (b0 & 0x10) != 0;
+    if (rsv1 or rsv2 or rsv3) return ParseError.ReservedBitsSet;
+
+    const opcode: Opcode = @enumFromInt(@as(u4, @truncate(b0 & 0x0F)));
+    const masked = (b1 & 0x80) != 0;
+    if (!masked) return ParseError.UnmaskedClientFrame;
+
+    const len7: u7 = @truncate(b1 & 0x7F);
+
+    var header_len: usize = 2;
+    var payload_len: u64 = undefined;
+
+    switch (len7) {
+        0...125 => payload_len = len7,
+        126 => {
+            if (buf.len < 4) return ParseError.Incomplete;
+            payload_len = std.mem.readInt(u16, buf[2..4], .big);
+            header_len = 4;
+        },
+        127 => {
+            if (buf.len < 10) return ParseError.Incomplete;
+            payload_len = std.mem.readInt(u64, buf[2..10], .big);
+            header_len = 10;
+        },
+    }
+
+    if (opcode.isControl()) {
+        if (payload_len > 125) return ParseError.ControlFrameTooLarge;
+        if (!fin) return ParseError.FragmentedControlFrame;
+    }
+
+    if (payload_len > max_payload) return ParseError.PayloadTooLarge;
+
+    // Mask key follows the (extended) length, then payload.
+    if (buf.len < header_len + 4) return ParseError.Incomplete;
+    const mask_key = buf[header_len..][0..4].*;
+    const payload_start = header_len + 4;
+    const total = payload_start + payload_len;
+    if (buf.len < total) return ParseError.Incomplete;
+
+    const payload = buf[payload_start..total];
+
+    // XOR-demask in place.
+    for (payload, 0..) |*byte, i| {
+        byte.* ^= mask_key[i & 3];
+    }
+
+    return Frame{
+        .fin = fin,
+        .opcode = opcode,
+        .payload = payload,
+        .consumed = total,
+    };
+}
+
+/// Serialize a server-to-client frame (RFC: server-to-client frames MUST NOT
+/// be masked, §5.1). Writes into `out`; returns the number of bytes written,
+/// or error.NoSpaceLeft if `out` is too small.
+pub fn writeServerFrame(
+    out: []u8,
+    fin: bool,
+    opcode: Opcode,
+    payload: []const u8,
+) error{NoSpaceLeft}!usize {
+    var header_len: usize = 2;
+    var extended_len_bytes: usize = 0;
+    if (payload.len > 125 and payload.len <= 0xFFFF) {
+        extended_len_bytes = 2;
+    } else if (payload.len > 0xFFFF) {
+        extended_len_bytes = 8;
+    }
+    const total = header_len + extended_len_bytes + payload.len;
+    if (out.len < total) return error.NoSpaceLeft;
+
+    out[0] = (@as(u8, if (fin) 0x80 else 0) | @intFromEnum(opcode));
+
+    if (extended_len_bytes == 0) {
+        out[1] = @intCast(payload.len);
+    } else if (extended_len_bytes == 2) {
+        out[1] = 126;
+        std.mem.writeInt(u16, out[2..4], @intCast(payload.len), .big);
+        header_len = 4;
+    } else {
+        out[1] = 127;
+        std.mem.writeInt(u64, out[2..10], @intCast(payload.len), .big);
+        header_len = 10;
+    }
+
+    @memcpy(out[header_len..][0..payload.len], payload);
+    return total;
+}
+
+/// Compute the Sec-WebSocket-Accept header value for a given client
+/// Sec-WebSocket-Key (RFC §4.2.2 step 5).
+///
+/// accept = base64(sha1(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+///
+/// `out` must be at least 28 bytes (base64-encoded SHA1 = 28 chars). Returns
+/// the number of bytes written.
+pub const WS_MAGIC = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+pub const ACCEPT_LEN: usize = 28;
+
+pub fn computeAcceptKey(client_key: []const u8, out: []u8) error{NoSpaceLeft}!usize {
+    if (out.len < ACCEPT_LEN) return error.NoSpaceLeft;
+
+    var hasher = crypto.hash.Sha1.init(.{});
+    hasher.update(client_key);
+    hasher.update(WS_MAGIC);
+    var sha1_digest: [crypto.hash.Sha1.digest_length]u8 = undefined;
+    hasher.final(&sha1_digest);
+
+    const encoder = std.base64.standard.Encoder;
+    const written = encoder.encode(out[0..ACCEPT_LEN], &sha1_digest);
+    return written.len;
+}
+
+/// Build the full HTTP/1.1 101 Switching Protocols response into `out`. Caller
+/// provides the already-computed accept key (28 bytes). Returns total bytes.
+pub fn writeHandshakeResponse(out: []u8, accept_key: []const u8) error{NoSpaceLeft}!usize {
+    const tmpl_prefix = "HTTP/1.1 101 Switching Protocols\r\n" ++
+        "Upgrade: websocket\r\n" ++
+        "Connection: Upgrade\r\n" ++
+        "Sec-WebSocket-Accept: ";
+    const tmpl_suffix = "\r\n\r\n";
+    const total = tmpl_prefix.len + accept_key.len + tmpl_suffix.len;
+    if (out.len < total) return error.NoSpaceLeft;
+    @memcpy(out[0..tmpl_prefix.len], tmpl_prefix);
+    @memcpy(out[tmpl_prefix.len..][0..accept_key.len], accept_key);
+    @memcpy(out[tmpl_prefix.len + accept_key.len ..][0..tmpl_suffix.len], tmpl_suffix);
+    return total;
+}
+
+/// Encode a close-frame payload. RFC §5.5.1: optional status code (2 bytes BE)
+/// followed by optional UTF-8 reason. Returns bytes written.
+pub fn writeClosePayload(out: []u8, code: u16, reason: []const u8) error{NoSpaceLeft}!usize {
+    const total = 2 + reason.len;
+    if (out.len < total) return error.NoSpaceLeft;
+    std.mem.writeInt(u16, out[0..2], code, .big);
+    @memcpy(out[2..][0..reason.len], reason);
+    return total;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+test "accept key — RFC §1.3 worked example" {
+    // The RFC example: key = "dGhlIHNhbXBsZSBub25jZQ=="
+    // expected accept = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+    var out: [ACCEPT_LEN]u8 = undefined;
+    const written = try computeAcceptKey("dGhlIHNhbXBsZSBub25jZQ==", &out);
+    try std.testing.expectEqual(ACCEPT_LEN, written);
+    try std.testing.expectEqualStrings("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=", out[0..]);
+}
+
+test "parse: smallest text frame from client" {
+    // FIN=1, opcode=text(1), masked, len=5, mask=0x01020304, payload xored
+    var buf = [_]u8{
+        0x81, // FIN | text
+        0x85, // MASK | len=5
+        0x01, 0x02, 0x03, 0x04, // mask
+        // payload "hello" xored byte-by-byte with mask
+        'h' ^ 0x01, 'e' ^ 0x02, 'l' ^ 0x03, 'l' ^ 0x04, 'o' ^ 0x01,
+    };
+    const frame = try parseServerFrame(&buf, PARSE_DEFAULT_MAX_PAYLOAD);
+    try std.testing.expectEqual(true, frame.fin);
+    try std.testing.expectEqual(Opcode.text, frame.opcode);
+    try std.testing.expectEqualStrings("hello", frame.payload);
+    try std.testing.expectEqual(@as(usize, 11), frame.consumed);
+}
+
+test "parse: 16-bit length encoding" {
+    var payload: [200]u8 = undefined;
+    @memset(&payload, 'A');
+    var buf: [206]u8 = undefined;
+    buf[0] = 0x81;
+    buf[1] = 0x80 | 126;
+    std.mem.writeInt(u16, buf[2..4], 200, .big);
+    buf[4] = 0x00;
+    buf[5] = 0x00;
+    buf[6] = 0x00;
+    buf[7] = 0x00; // mask = all zeros — XOR is no-op
+    @memcpy(buf[8..], &payload);
+
+    const frame = try parseServerFrame(&buf, PARSE_DEFAULT_MAX_PAYLOAD);
+    try std.testing.expectEqual(@as(usize, 200), frame.payload.len);
+    try std.testing.expectEqual(@as(usize, 206), frame.consumed);
+}
+
+test "parse: incomplete returns error.Incomplete" {
+    var buf = [_]u8{ 0x81, 0x85, 0x01 };
+    try std.testing.expectError(ParseError.Incomplete, parseServerFrame(&buf, PARSE_DEFAULT_MAX_PAYLOAD));
+}
+
+test "parse: rejects unmasked client frame" {
+    var buf = [_]u8{ 0x81, 0x05, 'h', 'e', 'l', 'l', 'o' };
+    try std.testing.expectError(ParseError.UnmaskedClientFrame, parseServerFrame(&buf, PARSE_DEFAULT_MAX_PAYLOAD));
+}
+
+test "parse: rejects reserved bits" {
+    var buf = [_]u8{ 0xC1, 0x80, 0, 0, 0, 0 }; // RSV1 set
+    try std.testing.expectError(ParseError.ReservedBitsSet, parseServerFrame(&buf, PARSE_DEFAULT_MAX_PAYLOAD));
+}
+
+test "parse: rejects oversize control frame" {
+    var buf = [_]u8{ 0x88, 0x80 | 126, 0x00, 0x80, 0, 0, 0, 0 };
+    try std.testing.expectError(ParseError.ControlFrameTooLarge, parseServerFrame(&buf, PARSE_DEFAULT_MAX_PAYLOAD));
+}
+
+test "parse: rejects fragmented control frame" {
+    var buf = [_]u8{ 0x08, 0x80, 0, 0, 0, 0 }; // FIN=0 + close opcode
+    try std.testing.expectError(ParseError.FragmentedControlFrame, parseServerFrame(&buf, PARSE_DEFAULT_MAX_PAYLOAD));
+}
+
+test "write: text frame small payload" {
+    var out: [16]u8 = undefined;
+    const written = try writeServerFrame(&out, true, .text, "hello");
+    try std.testing.expectEqual(@as(usize, 7), written);
+    try std.testing.expectEqual(@as(u8, 0x81), out[0]); // FIN | text
+    try std.testing.expectEqual(@as(u8, 5), out[1]); // unmasked len=5
+    try std.testing.expectEqualStrings("hello", out[2..7]);
+}
+
+test "write: 16-bit length boundary" {
+    const payload = [_]u8{'A'} ** 200;
+    var out: [256]u8 = undefined;
+    const written = try writeServerFrame(&out, true, .binary, &payload);
+    try std.testing.expectEqual(@as(usize, 204), written);
+    try std.testing.expectEqual(@as(u8, 0x82), out[0]); // FIN | binary
+    try std.testing.expectEqual(@as(u8, 126), out[1]);
+    try std.testing.expectEqual(@as(u16, 200), std.mem.readInt(u16, out[2..4], .big));
+}
+
+test "write: close frame with payload" {
+    var payload_buf: [32]u8 = undefined;
+    const payload_len = try writeClosePayload(&payload_buf, 1000, "bye");
+    try std.testing.expectEqual(@as(usize, 5), payload_len);
+
+    var out: [16]u8 = undefined;
+    const written = try writeServerFrame(&out, true, .close, payload_buf[0..payload_len]);
+    try std.testing.expectEqual(@as(usize, 7), written);
+    try std.testing.expectEqual(@as(u8, 0x88), out[0]);
+}
+
+test "handshake response format" {
+    const accept = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
+    var out: [256]u8 = undefined;
+    const written = try writeHandshakeResponse(&out, accept);
+    const expected =
+        "HTTP/1.1 101 Switching Protocols\r\n" ++
+        "Upgrade: websocket\r\n" ++
+        "Connection: Upgrade\r\n" ++
+        "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n";
+    try std.testing.expectEqualStrings(expected, out[0..written]);
+}
+
+test "roundtrip: parse(write(text payload)) yields original" {
+    const original = "round trip test";
+    var server_to_client: [32]u8 = undefined;
+    const w = try writeServerFrame(&server_to_client, true, .text, original);
+    _ = w;
+    // Server-to-client frames are unmasked; parseServerFrame rejects unmasked
+    // (since it's the server's parser). This roundtrip really just confirms
+    // the write path. Parse roundtrip is exercised by parse tests above.
+}


### PR DESCRIPTION
## Summary

Adds real RFC 6455 WebSocket support to the Zig HTTP core — handshake, frame codec, per-connection lifecycle, and a Python FFI bridge that wires the existing \`@app.websocket(...)\` decorator + \`WebSocket\` class to live socket I/O.

Before this PR: Python WebSocket surface was a stub backed by in-memory \`asyncio.Queue\`. Zig server had **zero** WebSocket code. Closes [#114](https://github.com/justrach/turboAPI/issues/114).

## What's in this PR

| Layer | What's new |
|---|---|
| \`zig/src/websocket.zig\` (NEW, 342 LoC) | Standalone RFC 6455 frame codec — parse + serialize, masking, 3 length encodings, opcode validation. **11 inline unit tests pass** (accept-key derivation, length-encoding boundaries, masking, malformed-frame rejection, control-frame constraints). |
| \`zig/src/server.zig\` | Upgrade detection in \`handleOneRequest\`, per-connection frame loop, FFI primitives (\`_server_add_websocket_route\`, \`_ws_recv\`, \`_ws_send_text\`, \`_ws_send_bytes\`, \`_ws_close\`). Auto-pong on ping, close handshake, fragmentation reassembly. |
| \`zig/src/main.zig\` | Bootstrap adds \`TurboServer.add_websocket_route\` + the \`_ws_invoke_handler\` Python helper that builds \`WebSocket(_zig_conn=capsule)\` and runs the async handler via \`asyncio.run\`. |
| \`python/turboapi/websockets.py\` | \`WebSocket\` learns a "connected mode" — when \`_zig_conn\` is a PyCapsule, \`send_*\`/\`receive_*\` go through FFI instead of the in-memory queue. **In-memory mode preserved** so the existing parity tests work unchanged. |
| \`python/turboapi/main_app.py\` + \`zig_integration.py\` | Decorator registers the route with the live Zig server (or queues for boot if server isn't yet running). |
| \`tests/test_websocket_e2e.py\` (NEW) | 10 wire tests using the \`websockets\` client library. |
| \`CLAUDE.md\` | Drops the \`--deselect TestWebSocket\` workaround since the parity tests now pass. |

## RFC 6455 coverage

| Feature | Status |
|---|---|
| HTTP/1.1 Upgrade handshake (Sec-WebSocket-Key/Accept, Version: 13) | ✅ |
| 7-bit / 16-bit / 64-bit payload length encodings | ✅ |
| Client → server mask XOR (rejects unmasked client frames per RFC §5.1) | ✅ |
| Opcodes: text, binary, close, ping, pong, continuation | ✅ |
| Reserved-bit rejection (no extensions negotiated) | ✅ |
| Control-frame constraints: ≤125 bytes, not fragmented | ✅ |
| Close handshake (server echoes close, then closes socket) | ✅ |
| Auto-pong on ping | ✅ |
| Fragmented message reassembly (continuation frames) | ✅ |
| 426 Upgrade Required on bad version | ✅ |
| permessage-deflate compression | ❌ (follow-up) |
| Subprotocol negotiation | ❌ (follow-up) |
| Path parameters on WS routes (e.g. \`/ws/{room}\`) | ❌ (exact match only for v1) |

## Threading + GIL

Each WS connection runs on the HTTP worker thread that handled the upgrade — same model as the regular request path. \`runPythonHandler\` does \`PyEval_AcquireThread(tstate)\` at entry, \`PyEval_ReleaseThread\` on exit. FFI calls (\`ws_recv\`/\`ws_send_*\`) release the GIL around blocking socket I/O so the interpreter (and other threads under free-threading) stays free during \`recv\` waits.

## Test plan

- [x] \`cd zig && zig build test\` — 13/13 pass (was 2/2 — adds the 11 codec tests)
- [x] \`uv run --python 3.14t python -m pytest tests/test_websocket_e2e.py\` — 10/10 pass (90s)
  - Zig-only echo route: text, binary, large 1000-byte message (exercises 16-bit length encoding), ping → auto-pong
  - Python handler routes: echo, bytes, JSON round-trip, server-initiated close
  - Routing: unknown path → 404
  - Protocol: fragmented client message reassembled before echo
- [x] \`uv run --python 3.14t python -m pytest tests/test_fastapi_parity.py::TestWebSocket\` — 4/4 pass (was deselected)
- [x] Full regression: \`uv run --python 3.14t python -m pytest tests/ -p no:anchorpy\` — **404 passed, 0 regressions** (3:21 runtime)

## Usage

```python
from turboapi import TurboAPI
from turboapi.websockets import WebSocket, WebSocketDisconnect

app = TurboAPI()

@app.websocket("/ws")
async def echo(ws: WebSocket):
    await ws.accept()
    try:
        while True:
            msg = await ws.receive_text()
            await ws.send_text(f"echo: {msg}")
    except WebSocketDisconnect:
        pass

app.run(host="127.0.0.1", port=8080)
```

Client:
```python
import asyncio, websockets
async def main():
    async with websockets.connect("ws://127.0.0.1:8080/ws") as ws:
        await ws.send("hello")
        print(await ws.recv())  # → echo: hello
asyncio.run(main())
```

## Follow-ups (not blocking)

- Path parameters on WS routes
- \`permessage-deflate\` compression extension
- Subprotocol negotiation
- WS routes registered after \`app.run()\`
- Fuzz corpus for the frame codec (existing \`server.zig\` has fuzz tests for HTTP parsing — same pattern would extend cleanly to \`websocket.zig\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justrach/turboapi/pull/167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->