### PR TITLE
Harden production errors docs and request framing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ where = ["python"]
 [tool.setuptools.package-data]
 turboapi = ["*.so", "*.dylib", "*.pyd"]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [tool.ruff]
 target-version = "py314"
 line-length = 100

--- a/python/turboapi/main_app.py
+++ b/python/turboapi/main_app.py
@@ -71,12 +71,14 @@ class TurboAPI(Router):
         redoc_url: str | None = "/redoc",
         openapi_url: str | None = "/openapi.json",
         lifespan: Callable | None = None,
+        debug: bool = False,
         **kwargs,
     ):
         super().__init__()
         self.title = title
         self.version = version
         self.description = description
+        self.debug = debug
         self.middleware_stack = []
         self.startup_handlers = []
         self.shutdown_handlers = []
@@ -406,7 +408,10 @@ class TurboAPI(Router):
             }
 
         except Exception as e:
-            return {"error": "Internal Server Error", "status_code": 500, "detail": str(e)}
+            response = {"error": "Internal Server Error", "status_code": 500}
+            if self.debug:
+                response["detail"] = str(e)
+            return response
 
     def run_legacy(self, host: str = "127.0.0.1", port: int = 8000, workers: int = 1, **kwargs):
         """Run the TurboAPI application with legacy loop sharding (DEPRECATED).
@@ -707,7 +712,8 @@ class TurboAPI(Router):
             else:
                 result = route.handler(**call_args)
         except Exception as e:
-            resp_body = _json.dumps({"detail": str(e)}).encode("utf-8")
+            detail = str(e) if self.debug else "Internal Server Error"
+            resp_body = _json.dumps({"detail": detail}).encode("utf-8")
             await send(
                 {
                     "type": "http.response.start",

--- a/python/turboapi/request_handler.py
+++ b/python/turboapi/request_handler.py
@@ -17,6 +17,24 @@ from turboapi.serializers import json_loads as _turbo_loads
 
 _NO_COERCION = object()
 
+
+def _internal_error_body(exc: Exception, *, debug: bool = False, include_traceback: bool = False) -> dict:
+    """Return the response body for unexpected 500 errors.
+
+    Production defaults intentionally avoid echoing exception strings or tracebacks,
+    which can contain secrets. Debug mode keeps the previous developer-friendly
+    details.
+    """
+    body = {"error": "Internal Server Error"}
+    if debug:
+        body["detail"] = str(exc)
+        if include_traceback:
+            import traceback
+
+            body["traceback"] = traceback.format_exc()
+    return body
+
+
 def _collect_streaming_body_sync(result):
     """If result is a StreamingResponse, collect its body synchronously."""
     if not hasattr(result, "body_iterator"):
@@ -665,11 +683,11 @@ class ResponseHandler:
             if isinstance(body, bytes):
                 # Try to decode as JSON for JSONResponse
                 try:
-                    import json
-
                     body = _turbo_loads(body)
-                except json.JSONDecodeError:
-                    # Not JSON, try as plain text
+                except Exception:
+                    # Not JSON, try as plain text. The active JSON backend may
+                    # raise json.JSONDecodeError, msgspec.DecodeError, or a
+                    # backend-specific exception type.
                     try:
                         body = body.decode("utf-8")
                     except UnicodeDecodeError:
@@ -677,11 +695,6 @@ class ResponseHandler:
                         if extra_headers:
                             return body, result.status_code, content_type, extra_headers
                         return body, result.status_code, content_type
-                except UnicodeDecodeError:
-                    # Binary data - return with content_type
-                    if extra_headers:
-                        return body, result.status_code, content_type, extra_headers
-                    return body, result.status_code, content_type
             if extra_headers:
                 return body, result.status_code, content_type, extra_headers
             return body, result.status_code, content_type
@@ -804,7 +817,7 @@ def _format_zig_tuple(content, status_code, content_type=None):
         return (status_code, "application/json", _json_dumps({"error": str(content)}))
 
 
-def create_enhanced_handler(original_handler, route_definition):
+def create_enhanced_handler(original_handler, route_definition, *, debug: bool = False):
     """
     Create an enhanced handler with automatic body parsing and response normalization.
 
@@ -1064,14 +1077,8 @@ def create_enhanced_handler(original_handler, route_definition):
 
                 if isinstance(e, HTTPException):
                     return ResponseHandler.format_json_response({"detail": e.detail}, e.status_code)
-                import traceback
-
                 return ResponseHandler.format_json_response(
-                    {
-                        "error": "Internal Server Error",
-                        "detail": str(e),
-                        "traceback": traceback.format_exc(),
-                    },
+                    _internal_error_body(e, debug=debug, include_traceback=True),
                     500,
                 )
 
@@ -1247,21 +1254,15 @@ def create_enhanced_handler(original_handler, route_definition):
 
                 if isinstance(e, HTTPException):
                     return ResponseHandler.format_json_response({"detail": e.detail}, e.status_code)
-                import traceback
-
                 return ResponseHandler.format_json_response(
-                    {
-                        "error": "Internal Server Error",
-                        "detail": str(e),
-                        "traceback": traceback.format_exc(),
-                    },
+                    _internal_error_body(e, debug=debug, include_traceback=True),
                     500,
                 )
 
         return enhanced_handler
 
 
-def create_pos_handler(original_handler):
+def create_pos_handler(original_handler, *, debug: bool = False):
     """Minimal positional wrapper for PyObject_Vectorcall dispatch.
 
     Zig assembles args from path/query params and calls this positionally —
@@ -1297,12 +1298,12 @@ def create_pos_handler(original_handler):
                     return (e.status_code, "application/json", _dumps({"detail": e.detail}))
             except ImportError:
                 pass
-            return (500, "application/json", _dumps({"error": str(e)}))
+            return (500, "application/json", _dumps(_internal_error_body(e, debug=debug)))
 
     return pos_handler
 
 
-def create_async_pos_handler(original_handler):
+def create_async_pos_handler(original_handler, *, debug: bool = False):
     """Minimal positional wrapper for async PyObject_Vectorcall dispatch."""
     import json as _json
 
@@ -1333,12 +1334,12 @@ def create_async_pos_handler(original_handler):
                     return (e.status_code, "application/json", _dumps({"detail": e.detail}))
             except ImportError:
                 pass
-            return (500, "application/json", _dumps({"error": str(e)}))
+            return (500, "application/json", _dumps(_internal_error_body(e, debug=debug)))
 
     return pos_handler
 
 
-def create_fast_handler(original_handler, route_definition):
+def create_fast_handler(original_handler, route_definition, *, debug: bool = False):
     """Create a minimal-overhead handler for simple sync routes.
 
     Returns a 3-tuple (status_code, content_type, body_str) so Zig can unpack
@@ -1397,7 +1398,7 @@ def create_fast_handler(original_handler, route_definition):
                         return (e.status_code, "application/json", _dumps({"detail": e.detail}))
                 except ImportError:
                     pass
-                return (500, "application/json", _dumps({"error": str(e)}))
+                return (500, "application/json", _dumps(_internal_error_body(e, debug=debug)))
 
         return fast_handler_noargs
 
@@ -1466,12 +1467,12 @@ def create_fast_handler(original_handler, route_definition):
                     return (e.status_code, "application/json", _dumps({"detail": e.detail}))
             except ImportError:
                 pass
-            return (500, "application/json", _dumps({"error": str(e)}))
+            return (500, "application/json", _dumps(_internal_error_body(e, debug=debug)))
 
     return fast_handler
 
 
-def create_fast_async_handler(original_handler, route_definition, eager: bool = False):
+def create_fast_async_handler(original_handler, route_definition, eager: bool = False, *, debug: bool = False):
     """Create a minimal-overhead tuple handler for async routes that need kwargs."""
     import json as _json
 
@@ -1555,7 +1556,7 @@ def create_fast_async_handler(original_handler, route_definition, eager: bool = 
                         return (e.status_code, "application/json", _dumps({"detail": e.detail}))
                 except ImportError:
                     pass
-                return (500, "application/json", _dumps({"error": str(e)}))
+                return (500, "application/json", _dumps(_internal_error_body(e, debug=debug)))
 
         return fast_handler_eager
 
@@ -1589,12 +1590,12 @@ def create_fast_async_handler(original_handler, route_definition, eager: bool = 
                     return (e.status_code, "application/json", _dumps({"detail": e.detail}))
             except ImportError:
                 pass
-            return (500, "application/json", _dumps({"error": str(e)}))
+            return (500, "application/json", _dumps(_internal_error_body(e, debug=debug)))
 
     return fast_handler
 
 
-def create_fast_model_handler(original_handler, model_class, param_name):
+def create_fast_model_handler(original_handler, model_class, param_name, *, debug: bool = False):
     """Create a minimal handler for model_sync routes.
 
     Zig has already validated the JSON body against the schema.
@@ -1630,6 +1631,6 @@ def create_fast_model_handler(original_handler, model_class, param_name):
                     return (e.status_code, "application/json", _dumps({"detail": e.detail}))
             except ImportError:
                 pass
-            return (500, "application/json", _dumps({"error": str(e)}))
+            return (500, "application/json", _dumps(_internal_error_body(e, debug=debug)))
 
     return fast_model_handler

--- a/python/turboapi/testclient.py
+++ b/python/turboapi/testclient.py
@@ -408,9 +408,10 @@ class TestClient:
                     content=_json_encode(error_body),
                     headers=getattr(e, "headers", None) or {},
                 )
+            detail = str(e) if getattr(self.app, "debug", False) else "Internal Server Error"
             return TestResponse(
                 status_code=500,
-                content=_json_encode({"detail": str(e)}),
+                content=_json_encode({"detail": detail}),
             )
 
         # Run background tasks if any

--- a/python/turboapi/zig_integration.py
+++ b/python/turboapi/zig_integration.py
@@ -724,6 +724,36 @@ class ZigIntegratedTurboAPI(TurboAPI):
             for method, path, status, ct, body in getattr(self, "_static_routes", []):
                 self.zig_server.add_static_route(method, path, status, ct, body)
 
+            # Register generated docs/schema routes for the native server path.
+            if self.openapi_url:
+                self.zig_server.add_static_route(
+                    "GET",
+                    self.openapi_url,
+                    200,
+                    "application/json",
+                    json.dumps(self.openapi()),
+                )
+            if self.docs_url:
+                from .openapi import get_swagger_ui_html
+
+                self.zig_server.add_static_route(
+                    "GET",
+                    self.docs_url,
+                    200,
+                    "text/html",
+                    get_swagger_ui_html(self.title, self.openapi_url or "/openapi.json"),
+                )
+            if self.redoc_url:
+                from .openapi import get_redoc_html
+
+                self.zig_server.add_static_route(
+                    "GET",
+                    self.redoc_url,
+                    200,
+                    "text/html",
+                    get_redoc_html(self.title, self.openapi_url or "/openapi.json"),
+                )
+
             # Configure DB pool (if configured)
             if hasattr(self, "_db_config"):
                 conn_str, pool_size = self._db_config
@@ -916,7 +946,7 @@ class ZigIntegratedTurboAPI(TurboAPI):
                         # Middleware present: register as "enhanced" so Zig uses callPythonHandler
                         # (dict response path). Pre-GIL dhi validation is skipped — middleware
                         # overhead already dominates, so the tradeoff is acceptable.
-                        enhanced_handler = create_enhanced_handler(route.handler, route)
+                        enhanced_handler = create_enhanced_handler(route.handler, route, debug=self.debug)
                         enhanced_handler = self._wrap_with_middleware(enhanced_handler)
                         self.zig_server.add_route_fast(
                             route.method.value,
@@ -935,6 +965,7 @@ class ZigIntegratedTurboAPI(TurboAPI):
                             route.handler,
                             model_info["model_class"],
                             model_info["param_name"],
+                            debug=self.debug,
                         )
 
                         # Extract dhi model schema for Zig-native validation
@@ -968,15 +999,15 @@ class ZigIntegratedTurboAPI(TurboAPI):
                         # Middleware present: wrap with enhanced handler, register as "enhanced"
                         # so Zig dispatches through callPythonHandler (dict response path)
                         # instead of the fast tuple path which doesn't support middleware
-                        enhanced_handler = create_enhanced_handler(route.handler, route)
+                        enhanced_handler = create_enhanced_handler(route.handler, route, debug=self.debug)
                         enhanced_handler = self._wrap_with_middleware(enhanced_handler)
                         registered_type = "enhanced"
                     elif handler_type == "simple_sync":
                         # Vectorcall path: Zig assembles args, calls positionally
-                        enhanced_handler = create_pos_handler(route.handler)
+                        enhanced_handler = create_pos_handler(route.handler, debug=self.debug)
                         registered_type = handler_type
                     else:
-                        enhanced_handler = create_fast_handler(route.handler, route)
+                        enhanced_handler = create_fast_handler(route.handler, route, debug=self.debug)
                         registered_type = handler_type
 
                     # simple_sync: ordered "name:type[?]|..." string for Zig vectorcall arg assembly
@@ -1012,7 +1043,7 @@ class ZigIntegratedTurboAPI(TurboAPI):
                 ):
                     # ASYNC FAST PATH: Register with async runtime
                     if self._middleware_instances:
-                        enhanced_handler = create_enhanced_handler(route.handler, route)
+                        enhanced_handler = create_enhanced_handler(route.handler, route, debug=self.debug)
                         enhanced_handler = self._wrap_with_middleware(enhanced_handler)
                         registered_type = "enhanced"
                         param_meta_str = "{}"
@@ -1033,6 +1064,7 @@ class ZigIntegratedTurboAPI(TurboAPI):
                             route.handler,
                             route,
                             eager=handler_type == "body_async_eager",
+                            debug=self.debug,
                         )
                         registered_type = handler_type
                         param_meta_str = json.dumps(param_types)
@@ -1049,7 +1081,7 @@ class ZigIntegratedTurboAPI(TurboAPI):
                 elif handler_type in ("form_sync", "file_sync"):
                     # FORM/FILE PATH: Enhanced handler with dedicated Zig dispatch
                     # Zig skips DHI validation and parses multipart/urlencoded natively
-                    enhanced_handler = create_enhanced_handler(route.handler, route)
+                    enhanced_handler = create_enhanced_handler(route.handler, route, debug=self.debug)
                     if self._middleware_instances:
                         enhanced_handler = self._wrap_with_middleware(enhanced_handler)
                         registered_type = "enhanced"
@@ -1067,7 +1099,7 @@ class ZigIntegratedTurboAPI(TurboAPI):
                     print(f"{CHECK_MARK} [{registered_type}] {route.method.value} {route.path}")
                 else:
                     # ENHANCED PATH: Full Python wrapper needed
-                    enhanced_handler = create_enhanced_handler(route.handler, route)
+                    enhanced_handler = create_enhanced_handler(route.handler, route, debug=self.debug)
                     if self._middleware_instances:
                         enhanced_handler = self._wrap_with_middleware(enhanced_handler)
                     self.zig_server.add_route(

--- a/tests/test_error_redaction.py
+++ b/tests/test_error_redaction.py
@@ -1,0 +1,118 @@
+import asyncio
+import json
+
+from turboapi import HTTPException, TurboAPI
+from turboapi.request_handler import (
+    create_fast_handler,
+    create_pos_handler,
+)
+from turboapi.routing import HTTPMethod
+from turboapi.testclient import TestClient
+
+
+class _Route:
+    method = HTTPMethod.GET
+    path = "/boom"
+
+
+def test_testclient_redacts_unexpected_errors_by_default():
+    app = TurboAPI()
+
+    @app.get("/boom")
+    def boom():
+        raise RuntimeError("secret-token")
+
+    response = TestClient(app).get("/boom")
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Internal Server Error"}
+    assert "secret-token" not in response.text
+
+
+def test_testclient_debug_includes_unexpected_error_detail():
+    app = TurboAPI(debug=True)
+
+    @app.get("/boom")
+    def boom():
+        raise RuntimeError("secret-token")
+
+    response = TestClient(app).get("/boom")
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "secret-token"}
+
+
+def test_http_exception_detail_is_preserved():
+    app = TurboAPI()
+
+    @app.get("/nope")
+    def nope():
+        raise HTTPException(status_code=418, detail="teapot")
+
+    response = TestClient(app).get("/nope")
+
+    assert response.status_code == 418
+    assert response.json() == {"detail": "teapot"}
+
+
+def test_fast_handler_redacts_unexpected_errors_by_default():
+    def boom():
+        raise RuntimeError("secret-token")
+
+    handler = create_fast_handler(boom, _Route())
+    status, content_type, body = handler()
+
+    assert status == 500
+    assert content_type == "application/json"
+    assert json.loads(body) == {"error": "Internal Server Error"}
+    assert "secret-token" not in body
+
+
+def test_fast_handler_debug_includes_unexpected_error_detail():
+    def boom():
+        raise RuntimeError("secret-token")
+
+    handler = create_fast_handler(boom, _Route(), debug=True)
+    status, _, body = handler()
+
+    assert status == 500
+    assert json.loads(body) == {"error": "Internal Server Error", "detail": "secret-token"}
+
+
+def test_pos_handler_redacts_unexpected_errors_by_default():
+    def boom():
+        raise RuntimeError("secret-token")
+
+    handler = create_pos_handler(boom)
+    status, _, body = handler()
+
+    assert status == 500
+    assert json.loads(body) == {"error": "Internal Server Error"}
+
+
+def test_handle_request_redacts_unexpected_errors_by_default():
+    app = TurboAPI()
+
+    @app.get("/boom")
+    def boom():
+        raise RuntimeError("secret-token")
+
+    result = asyncio.run(app.handle_request("GET", "/boom"))
+
+    assert result == {"error": "Internal Server Error", "status_code": 500}
+
+
+def test_handle_request_debug_includes_unexpected_error_detail():
+    app = TurboAPI(debug=True)
+
+    @app.get("/boom")
+    def boom():
+        raise RuntimeError("secret-token")
+
+    result = asyncio.run(app.handle_request("GET", "/boom"))
+
+    assert result == {
+        "error": "Internal Server Error",
+        "status_code": 500,
+        "detail": "secret-token",
+    }

--- a/tests/test_native_docs_registration.py
+++ b/tests/test_native_docs_registration.py
@@ -1,0 +1,74 @@
+import json
+
+from turboapi import TurboAPI
+
+
+class FakeTurboServer:
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+        self.static_routes = []
+        self.fast_routes = []
+        self.native_routes = []
+        self.db_routes = []
+
+    def add_static_route(self, method, path, status, content_type, body):
+        self.static_routes.append((method, path, status, content_type, body))
+
+    def add_route_fast(self, *args):
+        self.fast_routes.append(args)
+
+    def add_route_async_fast(self, *args):
+        self.fast_routes.append(args)
+
+    def add_native_route(self, *args):
+        self.native_routes.append(args)
+
+    def add_db_route(self, *args):
+        self.db_routes.append(args)
+
+    def enable_response_cache(self):
+        pass
+
+
+def test_native_server_registers_docs_and_openapi(monkeypatch):
+    import turboapi.zig_integration as zi
+
+    monkeypatch.setattr(zi, "NATIVE_CORE_AVAILABLE", True)
+    monkeypatch.setattr(zi.turbonet, "TurboServer", FakeTurboServer)
+
+    app = TurboAPI(title="Native Docs Test", version="9.9.9")
+
+    @app.get("/items/{item_id}")
+    def get_item(item_id: int):
+        return {"item_id": item_id}
+
+    assert app._initialize_zig_server("127.0.0.1", 0) is True
+
+    routes = {path: (method, status, content_type, body) for method, path, status, content_type, body in app.zig_server.static_routes}
+    assert "/openapi.json" in routes
+    assert "/docs" in routes
+    assert "/redoc" in routes
+
+    _, status, content_type, body = routes["/openapi.json"]
+    assert status == 200
+    assert content_type == "application/json"
+    schema = json.loads(body)
+    assert schema["info"]["title"] == "Native Docs Test"
+    assert schema["info"]["version"] == "9.9.9"
+
+    assert "SwaggerUIBundle" in routes["/docs"][3]
+    assert "/openapi.json" in routes["/docs"][3]
+    assert "redoc" in routes["/redoc"][3].lower()
+
+
+def test_native_server_respects_disabled_docs_urls(monkeypatch):
+    import turboapi.zig_integration as zi
+
+    monkeypatch.setattr(zi, "NATIVE_CORE_AVAILABLE", True)
+    monkeypatch.setattr(zi.turbonet, "TurboServer", FakeTurboServer)
+
+    app = TurboAPI(docs_url=None, redoc_url=None, openapi_url=None)
+    assert app._initialize_zig_server("127.0.0.1", 0) is True
+
+    assert app.zig_server.static_routes == []

--- a/tests/test_perf_callnoargs_tupleabi.py
+++ b/tests/test_perf_callnoargs_tupleabi.py
@@ -184,7 +184,7 @@ def test_fast_async_handler_eager_returns_tuple_from_body():
 
 
 def test_fast_handler_exception_returns_500_tuple():
-    """Uncaught exception inside handler returns (500, ...) tuple."""
+    """Uncaught exception inside handler returns redacted (500, ...) tuple."""
 
     def handler():
         raise RuntimeError("boom")
@@ -197,7 +197,12 @@ def test_fast_handler_exception_returns_500_tuple():
     import json
 
     data = json.loads(result[2])
-    assert "boom" in data["error"]
+    assert data == {"error": "Internal Server Error"}
+
+    debug_h = create_fast_handler(handler, route, debug=True)
+    debug_result = debug_h(path_params={})
+    debug_data = json.loads(debug_result[2])
+    assert debug_data == {"error": "Internal Server Error", "detail": "boom"}
 
 
 # ── Tuple ABI: create_fast_model_handler returns 3-tuples ────────────────────

--- a/tests/test_release_version_sync.py
+++ b/tests/test_release_version_sync.py
@@ -32,4 +32,5 @@ def test_release_versions_are_in_sync():
 
 def test_release_version_bumped_past_bad_1_0_25_publish():
     """This release must move past the broken 1.0.25/1.0.26 artifact publishes."""
-    assert _read_pyproject_version() == "1.0.27"
+    version = tuple(int(part) for part in _read_pyproject_version().split("."))
+    assert version >= (1, 0, 27)

--- a/zig/src/server.zig
+++ b/zig/src/server.zig
@@ -1152,13 +1152,15 @@ fn runIoUringAcceptLoop(tcp_server: *std.Io.net.Server) !void {
 /// existing per-connection thread-pool code can consume it unchanged.
 fn iouringOnAccept(ctx: *anyopaque, fd: posix.fd_t) void {
     const conn_pool: *ConnectionPool = @ptrCast(@alignCast(ctx));
-    const stream = std.Io.net.Stream{ .socket = .{
-        .handle = fd,
-        // peer address isn't reported by ACCEPT_MULTISHOT when we pass a
-        // null sockaddr; the existing handlers don't read it, so leave it
-        // zero rather than paying for getpeername(2) on the hot path.
-        .address = .{ .ip4 = std.Io.net.Ip4Address.unspecified(0) },
-    } };
+    const stream = std.Io.net.Stream{
+        .socket = .{
+            .handle = fd,
+            // peer address isn't reported by ACCEPT_MULTISHOT when we pass a
+            // null sockaddr; the existing handlers don't read it, so leave it
+            // zero rather than paying for getpeername(2) on the hot path.
+            .address = .{ .ip4 = std.Io.net.Ip4Address.unspecified(0) },
+        },
+    };
     conn_pool.queue.push(stream);
 }
 
@@ -1184,6 +1186,76 @@ fn parseHeaders(request_data: []const u8, first_line_end: usize, header_end_pos:
     }
 
     return headers;
+}
+
+const FramingError = enum {
+    none,
+    invalid_content_length,
+    conflicting_content_length,
+    unsupported_transfer_encoding,
+    transfer_encoding_with_content_length,
+};
+
+const FramingResult = struct {
+    content_length: usize = 0,
+    has_content_length: bool = false,
+    has_transfer_encoding: bool = false,
+    err: FramingError = .none,
+};
+
+fn parseFramingHeaders(request_data: []const u8, first_line_end: usize, header_end_pos: usize) FramingResult {
+    var result = FramingResult{};
+    var seen_content_length: ?usize = null;
+
+    var pos = first_line_end + 2;
+    while (pos < header_end_pos) {
+        const line_end = std.mem.indexOfPos(u8, request_data, pos, "\r\n") orelse header_end_pos;
+        const line = request_data[pos..line_end];
+        pos = line_end + 2;
+
+        if (line.len == 0) break;
+        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+        const name = std.mem.trim(u8, line[0..colon], " \t");
+        const value = std.mem.trim(u8, line[colon + 1 ..], " \t");
+
+        if (std.ascii.eqlIgnoreCase(name, "transfer-encoding")) {
+            result.has_transfer_encoding = true;
+        } else if (std.ascii.eqlIgnoreCase(name, "content-length")) {
+            if (value.len == 0) {
+                result.err = .invalid_content_length;
+                return result;
+            }
+            for (value) |ch| {
+                if (ch < '0' or ch > '9') {
+                    result.err = .invalid_content_length;
+                    return result;
+                }
+            }
+            const parsed = std.fmt.parseInt(usize, value, 10) catch {
+                result.err = .invalid_content_length;
+                return result;
+            };
+            if (seen_content_length) |previous| {
+                if (previous != parsed) {
+                    result.err = .conflicting_content_length;
+                    return result;
+                }
+            } else {
+                seen_content_length = parsed;
+            }
+        }
+    }
+
+    if (seen_content_length) |cl| {
+        result.has_content_length = true;
+        result.content_length = cl;
+    }
+    if (result.has_transfer_encoding and result.has_content_length) {
+        result.err = .transfer_encoding_with_content_length;
+    } else if (result.has_transfer_encoding) {
+        result.err = .unsupported_transfer_encoding;
+    }
+    return result;
 }
 
 /// SIMD-accelerated search for the HTTP header-end sentinel "\r\n\r\n".
@@ -1272,11 +1344,46 @@ fn handleOneRequest(stream: std.Io.net.Stream, tstate: ?*anyopaque) !void {
     const path = if (q_idx) |i| raw_path[0..i] else raw_path;
     const query_string = if (q_idx) |i| raw_path[i + 1 ..] else "";
 
+    const framing = parseFramingHeaders(request_head, first_line_end, he);
+    switch (framing.err) {
+        .none => {},
+        .invalid_content_length, .conflicting_content_length => {
+            sendResponseClose(stream, 400, "application/json", "{\"error\": \"Invalid Content-Length\"}");
+            return error.InvalidRequest;
+        },
+        .transfer_encoding_with_content_length => {
+            sendResponseClose(stream, 400, "application/json", "{\"error\": \"Conflicting Transfer-Encoding and Content-Length\"}");
+            return error.InvalidRequest;
+        },
+        .unsupported_transfer_encoding => {
+            sendResponseClose(stream, 501, "application/json", "{\"error\": \"Transfer-Encoding not supported\"}");
+            return error.InvalidRequest;
+        },
+    }
+
+    const max_body: usize = 16 * 1024 * 1024;
+    if (framing.content_length > max_body) {
+        sendResponseClose(stream, 413, "application/json", "{\"error\": \"Payload Too Large\"}");
+        return error.InvalidRequest;
+    }
+    if (!framing.has_content_length and total_read > he + 4) {
+        sendResponseClose(stream, 400, "application/json", "{\"error\": \"Unexpected bytes after headers\"}");
+        return error.InvalidRequest;
+    }
+    if (framing.has_content_length and total_read > he + 4 + framing.content_length) {
+        sendResponseClose(stream, 400, "application/json", "{\"error\": \"Unexpected bytes after request body\"}");
+        return error.InvalidRequest;
+    }
+
     // Phase 3: Route match EARLY — before header parsing, so fast handlers
     // can skip the expensive parseHeaders + body read entirely.
     const rt = getRouter();
     var match = rt.findRoute(method, path) orelse {
         logger.debug("[ZIG] 404 for {s} {s}", .{ method, path });
+        if (framing.content_length > 0) {
+            sendResponseClose(stream, 404, "application/json", "{\"error\": \"Not Found\"}");
+            return error.InvalidRequest;
+        }
         sendResponse(stream, 404, "application/json", "{\"error\": \"Not Found\"}");
         return;
     };
@@ -1286,6 +1393,10 @@ fn handleOneRequest(stream: std.Io.net.Stream, tstate: ?*anyopaque) !void {
 
     // CORS preflight — immediate 204, no Python
     if (cors_enabled and std.mem.eql(u8, method, "OPTIONS")) {
+        if (framing.content_length > 0) {
+            sendResponseClose(stream, 400, "application/json", "{\"error\": \"Unexpected request body\"}");
+            return error.InvalidRequest;
+        }
         sendResponse(stream, 204, "", "");
         return;
     }
@@ -1293,6 +1404,10 @@ fn handleOneRequest(stream: std.Io.net.Stream, tstate: ?*anyopaque) !void {
     // Static routes — single writeAll of pre-rendered bytes
     const sr = getStaticRoutes();
     if (sr.get(match.handler_key)) |static_entry| {
+        if (framing.content_length > 0) {
+            sendResponseClose(stream, 400, "application/json", "{\"error\": \"Unexpected request body\"}");
+            return error.InvalidRequest;
+        }
         streamWriteAll(stream, static_entry.response_bytes) catch return;
         return;
     }
@@ -1300,6 +1415,10 @@ fn handleOneRequest(stream: std.Io.net.Stream, tstate: ?*anyopaque) !void {
     // Native FFI routes — no GIL, no Python
     const nr = getNativeRoutes();
     if (nr.get(match.handler_key)) |native_entry| {
+        if (framing.content_length > 0) {
+            sendResponseClose(stream, 400, "application/json", "{\"error\": \"Unexpected request body\"}");
+            return error.InvalidRequest;
+        }
         // Native handlers need headers — parse them
         var headers = parseHeaders(request_head, first_line_end, he);
         defer headers.deinit(allocator);
@@ -1323,14 +1442,7 @@ fn handleOneRequest(stream: std.Io.net.Stream, tstate: ?*anyopaque) !void {
     if (dbr.get(match.handler_key)) |*db_entry| {
         if (db_entry.op == .insert) {
             // INSERT needs body — parse headers + read body
-            var db_headers = parseHeaders(request_head, first_line_end, he);
-            defer db_headers.deinit(allocator);
-            var db_cl: usize = 0;
-            for (db_headers.items) |h| {
-                if (std.ascii.eqlIgnoreCase(h.name, "content-length")) {
-                    db_cl = std.fmt.parseInt(usize, h.value, 10) catch 0;
-                }
-            }
+            const db_cl: usize = framing.content_length;
             const db_body_start = he + 4;
             const db_already = request_head[db_body_start..total_read];
             var db_body: []const u8 = "";
@@ -1358,6 +1470,10 @@ fn handleOneRequest(stream: std.Io.net.Stream, tstate: ?*anyopaque) !void {
             db.handleDbRoute(stream, db_entry, db_body, &match.params, query_string, &sendResponse);
         } else {
             // GET/DELETE — no body needed
+            if (framing.content_length > 0) {
+                sendResponseClose(stream, 400, "application/json", "{\"error\": \"Unexpected request body\"}");
+                return error.InvalidRequest;
+            }
             db.handleDbRoute(stream, db_entry, "", &match.params, query_string, &sendResponse);
         }
         return;
@@ -1373,6 +1489,15 @@ fn handleOneRequest(stream: std.Io.net.Stream, tstate: ?*anyopaque) !void {
     const entry = entry_ptr.*;
 
     // ── Ultra-fast path: simple handlers that don't need headers or body ──
+    switch (entry.handler_tag) {
+        .simple_sync_noargs, .simple_sync, .simple_async, .simple_async_eager => {
+            if (framing.content_length > 0) {
+                sendResponseClose(stream, 400, "application/json", "{\"error\": \"Unexpected request body\"}");
+                return error.InvalidRequest;
+            }
+        },
+        else => {},
+    }
     switch (entry.handler_tag) {
         .simple_sync_noargs => {
             if (cache_noargs_responses) {
@@ -1444,33 +1569,7 @@ fn handleOneRequest(stream: std.Io.net.Stream, tstate: ?*anyopaque) !void {
     const body_start = he + 4;
     const already_read_body = request_head[body_start..total_read];
 
-    // Reject Transfer-Encoding (chunked not implemented — accepting silently causes request smuggling)
-    var has_te = false;
-    var has_cl = false;
-    var content_length: usize = 0;
-    for (headers.items) |h| {
-        if (std.ascii.eqlIgnoreCase(h.name, "transfer-encoding")) has_te = true;
-        if (std.ascii.eqlIgnoreCase(h.name, "content-length")) {
-            has_cl = true;
-            content_length = std.fmt.parseInt(usize, h.value, 10) catch 0;
-        }
-    }
-    if (has_te) {
-        if (has_cl) {
-            // TE + CL = smuggling attack (RFC 7230 §3.3.3)
-            sendResponse(stream, 400, "application/json", "{\"error\": \"Conflicting Transfer-Encoding and Content-Length\"}");
-        } else {
-            // TE alone = unsupported encoding
-            sendResponse(stream, 501, "application/json", "{\"error\": \"Transfer-Encoding not supported\"}");
-        }
-        return;
-    }
-
-    const max_body: usize = 16 * 1024 * 1024;
-    if (content_length > max_body) {
-        sendResponse(stream, 413, "application/json", "{\"error\": \"Payload Too Large\"}");
-        return;
-    }
+    const content_length: usize = framing.content_length;
 
     var body: []const u8 = "";
     var body_owned: ?[]u8 = null;
@@ -2634,6 +2733,18 @@ fn statusText(status: u16) []const u8 {
 /// Zero-alloc response writer.  Header + body are concatenated into a stack
 /// buffer for a single write syscall (most API responses are <4KB).
 /// Falls back to two writes only for large responses.
+pub fn sendResponseClose(stream: std.Io.net.Stream, status: u16, content_type: []const u8, body: []const u8) void {
+    const date_str = currentHttpDate();
+    var header_buf: [512]u8 = undefined;
+    const header = std.fmt.bufPrint(
+        &header_buf,
+        "HTTP/1.1 {d} {s}\r\nServer: TurboAPI\r\nDate: {s}\r\nContent-Type: {s}\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n",
+        .{ status, statusText(status), date_str, content_type, body.len },
+    ) catch return;
+    streamWriteAll(stream, header) catch return;
+    if (body.len > 0) streamWriteAll(stream, body) catch return;
+}
+
 pub fn sendResponse(stream: std.Io.net.Stream, status: u16, content_type: []const u8, body: []const u8) void {
     // TFB requires Server + Date headers
     const date_str = currentHttpDate();
@@ -2738,6 +2849,52 @@ test "response cache is safe under concurrent access" {
     try std.testing.expectEqual(@as(usize, 2), response_cache_count);
     try std.testing.expectEqualStrings("{\"item_id\":1}", getCachedResponse("GET /items/1").?);
     try std.testing.expectEqualStrings("{\"item_id\":2}", getCachedResponse("GET /items/2").?);
+}
+
+test "HTTP framing parser validates Content-Length and Transfer-Encoding" {
+    const base = "GET / HTTP/1.1\r\nHost: example\r\n";
+
+    const valid = base ++ "Content-Length: 5\r\n\r\nhello";
+    const valid_result = parseFramingHeaders(valid, 14, valid.len - 9);
+    try std.testing.expectEqual(FramingError.none, valid_result.err);
+    try std.testing.expect(valid_result.has_content_length);
+    try std.testing.expectEqual(@as(usize, 5), valid_result.content_length);
+
+    const invalid_alpha = base ++ "Content-Length: abc\r\n\r\n";
+    try std.testing.expectEqual(
+        FramingError.invalid_content_length,
+        parseFramingHeaders(invalid_alpha, 14, invalid_alpha.len - 4).err,
+    );
+
+    const invalid_negative = base ++ "Content-Length: -1\r\n\r\n";
+    try std.testing.expectEqual(
+        FramingError.invalid_content_length,
+        parseFramingHeaders(invalid_negative, 14, invalid_negative.len - 4).err,
+    );
+
+    const duplicate_same = base ++ "Content-Length: 5\r\nContent-Length: 5\r\n\r\nhello";
+    try std.testing.expectEqual(
+        FramingError.none,
+        parseFramingHeaders(duplicate_same, 14, duplicate_same.len - 9).err,
+    );
+
+    const duplicate_conflict = base ++ "Content-Length: 5\r\nContent-Length: 6\r\n\r\nhello";
+    try std.testing.expectEqual(
+        FramingError.conflicting_content_length,
+        parseFramingHeaders(duplicate_conflict, 14, duplicate_conflict.len - 9).err,
+    );
+
+    const te_only = base ++ "Transfer-Encoding: chunked\r\n\r\n";
+    try std.testing.expectEqual(
+        FramingError.unsupported_transfer_encoding,
+        parseFramingHeaders(te_only, 14, te_only.len - 4).err,
+    );
+
+    const te_cl = base ++ "Transfer-Encoding: chunked\r\nContent-Length: 5\r\n\r\nhello";
+    try std.testing.expectEqual(
+        FramingError.transfer_encoding_with_content_length,
+        parseFramingHeaders(te_cl, 14, te_cl.len - 9).err,
+    );
 }
 
 // ── Fuzz tests ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add production-safe unexpected 500 redaction with TurboAPI(debug=True) detail mode
- Register /openapi.json, /docs, and /redoc in the native Zig server path
- Constrain pytest discovery to tests/ so vendored/auth-dependent tools are not collected by default
- Add strict Zig HTTP framing parsing for Content-Length / Transfer-Encoding edge cases
- Fix response normalization fallback for non-JSON byte responses under msgspec-backed JSON loading
- Update stale tests for redacted 500s and current release version guard

## Validation
- python -m py_compile python/turboapi/request_handler.py python/turboapi/main_app.py python/turboapi/zig_integration.py tests/test_error_redaction.py tests/test_native_docs_registration.py
- pytest tests/test_error_redaction.py tests/test_native_docs_registration.py tests/test_fastapi_parity.py::TestOpenAPI -q
- pytest tests/test_binary_responses.py::TestBinaryResponseNormalization::test_text_response_not_affected tests/test_issue_fixes.py::TestResponseSerialization tests/test_issue_fixes.py::TestResponseSerializationIntegration::test_response_object_returned_correctly tests/test_error_redaction.py tests/test_native_docs_registration.py -q
- pytest -q
- zig fmt --check zig/src/server.zig
- zig test zig/src/server.zig --test-filter framing
- git diff --check

Full pytest now collects repo tests only and passed: 400 passed, 23 warnings.

Note: full unfiltered zig test still has an unrelated pre-existing compile issue in the response-cache test expecting a string from getCachedResponse(), so this PR validates the new framing parser with --test-filter framing and the commit hook Zig build.