### PR TITLE
release: v1.0.32

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.31
+current_version = 1.0.32
 commit = False
 tag = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboapi"
-version = "1.0.31"
+version = "1.0.32"
 description = "FastAPI-compatible web framework with Zig HTTP core — 20x faster with Python 3.14 free-threading"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="turboapi",
-    version="1.0.31",
+    version="1.0.32",
     description="A high-performance Python web framework for the no-GIL era",
     long_description=open("../README.md").read(),
     long_description_content_type="text/markdown",

--- a/python/turboapi/__init__.py
+++ b/python/turboapi/__init__.py
@@ -94,7 +94,7 @@ from .version_check import check_free_threading_support, get_python_threading_in
 # WebSocket
 from .websockets import WebSocket, WebSocketDisconnect
 
-__version__ = "1.0.31"
+__version__ = "1.0.32"
 __all__ = [
     # Core
     "TurboAPI",


### PR DESCRIPTION
## Summary

Prepare TurboAPI `v1.0.32` for release.

This release includes the merged Linux ARM64 CPython 3.14t wheel work and its follow-up fixes:

- build and audit a `manylinux_2_28_aarch64` wheel;
- provide the wheel-only `getrandom` compatibility implementation required by Zig 0.16 without exposing `arc4random_buf`;
- exercise the installed native backend with a real HTTP request in CI;
- document and test the Apple `container` workflow;
- remove per-request DHI `model_dump` closure patching while retaining list-field compatibility.

## Version changes

- `.bumpversion.cfg`: `1.0.31` → `1.0.32`
- `pyproject.toml`: `1.0.31` → `1.0.32`
- `python/setup.py`: `1.0.31` → `1.0.32`
- `python/turboapi/__init__.py`: `1.0.31` → `1.0.32`

## Local verification

- `python -m pytest tests/test_release_version_sync.py tests/test_model_dump_compat.py -q`
- `ruff check python/turboapi/__init__.py python/setup.py tests/test_release_version_sync.py`
- `git diff --check`
- built `turboapi-1.0.32.tar.gz` and verified `PKG-INFO` reports `Version: 1.0.32`

After merge, tag `v1.0.32` to run the publish workflow. The release will not be considered complete until the PyPI ARM64 wheel is downloaded and smoked inside Apple `container`.
